### PR TITLE
Update project paths to kubernetes-helm/chartmuseum

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -74,7 +74,7 @@ endif
 ifndef HAS_DOT
 	@sudo apt-get update && sudo apt-get install -y graphviz
 endif
-	@goviz -i github.com/chartmuseum/chartmuseum/cmd/chartmuseum -l | dot -Tpng -o goviz.png
+	@goviz -i github.com/kubernetes-helm/chartmuseum/cmd/chartmuseum -l | dot -Tpng -o goviz.png
 
 .PHONY: release
 release:

--- a/circle.yml
+++ b/circle.yml
@@ -8,7 +8,7 @@ jobs:
       - image: circleci/golang:1.8
         environment:
           GOOGLE_APPLICATION_CREDENTIALS: /home/circleci/gcp-key.json
-    working_directory: /go/src/github.com/chartmuseum/chartmuseum
+    working_directory: /go/src/github.com/kubernetes-helm/chartmuseum
     steps:
       # Setup build environment
       - checkout

--- a/cmd/chartmuseum/main.go
+++ b/cmd/chartmuseum/main.go
@@ -6,8 +6,8 @@ import (
 	"os"
 	"strings"
 
-	"github.com/chartmuseum/chartmuseum/pkg/chartmuseum"
-	"github.com/chartmuseum/chartmuseum/pkg/storage"
+	"github.com/kubernetes-helm/chartmuseum/pkg/chartmuseum"
+	"github.com/kubernetes-helm/chartmuseum/pkg/storage"
 
 	"github.com/urfave/cli"
 )

--- a/cmd/chartmuseum/main_test.go
+++ b/cmd/chartmuseum/main_test.go
@@ -6,8 +6,8 @@ import (
 	"os"
 	"testing"
 
-	"github.com/chartmuseum/chartmuseum/pkg/chartmuseum"
-	"github.com/chartmuseum/chartmuseum/pkg/repo"
+	"github.com/kubernetes-helm/chartmuseum/pkg/chartmuseum"
+	"github.com/kubernetes-helm/chartmuseum/pkg/repo"
 
 	"github.com/stretchr/testify/suite"
 )

--- a/glide.yaml
+++ b/glide.yaml
@@ -1,4 +1,4 @@
-package: github.com/chartmuseum/chartmuseum
+package: github.com/kubernetes-helm/chartmuseum
 
 import:
 - package: github.com/gin-gonic/gin

--- a/pkg/chartmuseum/handlers.go
+++ b/pkg/chartmuseum/handlers.go
@@ -7,7 +7,7 @@ import (
 	"net/http"
 	"strings"
 
-	"github.com/chartmuseum/chartmuseum/pkg/repo"
+	"github.com/kubernetes-helm/chartmuseum/pkg/repo"
 
 	"github.com/gin-gonic/gin"
 )

--- a/pkg/chartmuseum/server.go
+++ b/pkg/chartmuseum/server.go
@@ -7,8 +7,8 @@ import (
 	"sync"
 	"time"
 
-	"github.com/chartmuseum/chartmuseum/pkg/repo"
-	"github.com/chartmuseum/chartmuseum/pkg/storage"
+	"github.com/kubernetes-helm/chartmuseum/pkg/repo"
+	"github.com/kubernetes-helm/chartmuseum/pkg/storage"
 
 	"github.com/gin-gonic/gin"
 	"github.com/zsais/go-gin-prometheus"

--- a/pkg/chartmuseum/server_test.go
+++ b/pkg/chartmuseum/server_test.go
@@ -14,7 +14,7 @@ import (
 	"testing"
 	"time"
 
-	"github.com/chartmuseum/chartmuseum/pkg/storage"
+	"github.com/kubernetes-helm/chartmuseum/pkg/storage"
 
 	"github.com/gin-gonic/gin"
 	"github.com/stretchr/testify/suite"

--- a/pkg/repo/chart.go
+++ b/pkg/repo/chart.go
@@ -7,7 +7,7 @@ import (
 	pathutil "path"
 	"strings"
 
-	"github.com/chartmuseum/chartmuseum/pkg/storage"
+	"github.com/kubernetes-helm/chartmuseum/pkg/storage"
 
 	"k8s.io/helm/pkg/chartutil"
 	helm_chart "k8s.io/helm/pkg/proto/hapi/chart"

--- a/pkg/repo/chart_test.go
+++ b/pkg/repo/chart_test.go
@@ -5,7 +5,7 @@ import (
 	"testing"
 	"time"
 
-	"github.com/chartmuseum/chartmuseum/pkg/storage"
+	"github.com/kubernetes-helm/chartmuseum/pkg/storage"
 
 	"github.com/stretchr/testify/suite"
 )


### PR DESCRIPTION
Since ChartMuseum has moved to the kubernetes-helm incubator, it can
now be found in GitHub under the kubernetes-helm project. In keeping
with this, update the project paths from chartmuseum/chartmuseum to
kubernetes-helm/chartmusuem.