### PR TITLE
Add X-Request-Id header

### DIFF
--- a/glide.lock
+++ b/glide.lock
@@ -1,5 +1,5 @@
-hash: 0fcbe5a7dd041e19510c745059a0134f11db16a14ae7f5bbfcf35070a5ed6422
-updated: 2017-11-24T23:52:10.792983635-06:00
+hash: faa3c5ff3d6dd6e6b6a809b36fbf562fdd4ee35e417022d82ce116d279adbaa4
+updated: 2017-11-26T18:02:11.580246452-06:00
 imports:
 - name: cloud.google.com/go
   version: 0f0b8420cb699ac4ce059c63bac263f4301fe95b
@@ -10,6 +10,8 @@ imports:
   - internal/optional
   - internal/version
   - storage
+- name: github.com/atarantini/ginrequestid
+  version: a432ade0ce478903613da1372cb5a62914cfe532
 - name: github.com/aws/aws-sdk-go
   version: 5e436e55ac5eddc739f26a2a209b3f4248ee8e0e
   subpackages:

--- a/glide.lock
+++ b/glide.lock
@@ -1,5 +1,5 @@
 hash: faa3c5ff3d6dd6e6b6a809b36fbf562fdd4ee35e417022d82ce116d279adbaa4
-updated: 2017-11-26T18:02:11.580246452-06:00
+updated: 2017-11-26T21:32:22.856349424-06:00
 imports:
 - name: cloud.google.com/go
   version: 0f0b8420cb699ac4ce059c63bac263f4301fe95b
@@ -113,6 +113,8 @@ imports:
   version: 65c1f6f8f0fc1e2185eb9863a3bc751496404259
   subpackages:
   - xfs
+- name: github.com/satori/go.uuid
+  version: 5bf94b69c6b68ee1b541973bb8e1144db23a194b
 - name: github.com/sirupsen/logrus
   version: 89742aefa4b206dcf400792f3bd35b542998eb3b
 - name: github.com/spf13/pflag

--- a/glide.yaml
+++ b/glide.yaml
@@ -13,6 +13,8 @@ import:
   version: v1.5.0
 - package: github.com/zsais/go-gin-prometheus
   version: e26effb6cde37935f313bb3d5e5a1207f44cff69
+- package: github.com/atarantini/ginrequestid
+  version: a432ade0ce478903613da1372cb5a62914cfe532
 
 # these ones are srsly a pain in da butt...
 # all needed to get cloud.google.com/go/storage to work

--- a/pkg/chartmuseum/cache.go
+++ b/pkg/chartmuseum/cache.go
@@ -26,6 +26,17 @@ import (
 	helm_repo "k8s.io/helm/pkg/repo"
 )
 
+type (
+	fetchedObjects struct {
+		objects []storage.Object
+		err     error
+	}
+	indexRegeneration struct {
+		index *repo.Index
+		err   error
+	}
+)
+
 // getChartList fetches from the server and accumulates concurrent requests to be fulfilled all at once.
 func (server *Server) getChartList(c *gin.Context) <-chan fetchedObjects {
 	ch := make(chan fetchedObjects, 1)

--- a/pkg/chartmuseum/cache.go
+++ b/pkg/chartmuseum/cache.go
@@ -1,0 +1,266 @@
+package chartmuseum
+
+/*
+__../)
+-._  \          /:
+_.-'  \        ( \___
+  ,'   \     .'`\.) :"-._______
+,' .'/||    / /   _ `""`  ```  `,        _ _  ~ - _
+ .' / ||   / |   ( `.~v~v~v~v~v'  _  -- *     *  _ -
+'  /  ||  | .\    `. `.  __-  ~ -     ~         --   -
+  /   ||  | :  `----`. `.  -~ _  _ ~ *           *  -
+ /    ||   \:_     /  `. `.  - *__   -    -       __
+/    .'/    `.`----\    `._;        --  _ *  -     _
+     ||      `,_    `                     - -__ -
+     ||       /  `---':
+          HERE BE DRAGONS!!!
+*/
+
+import (
+	"context"
+
+	"github.com/kubernetes-helm/chartmuseum/pkg/repo"
+	"github.com/kubernetes-helm/chartmuseum/pkg/storage"
+
+	"github.com/gin-gonic/gin"
+	helm_repo "k8s.io/helm/pkg/repo"
+)
+
+// getChartList fetches from the server and accumulates concurrent requests to be fulfilled all at once.
+func (server *Server) getChartList(c *gin.Context) <-chan fetchedObjects {
+	ch := make(chan fetchedObjects, 1)
+
+	server.fetchedObjectsLock.Lock()
+	server.fetchedObjectsChans = append(server.fetchedObjectsChans, ch)
+
+	if len(server.fetchedObjectsChans) == 1 {
+		// this unlock is wanted, while fetching the list, allow other channeled requests to be added
+		server.fetchedObjectsLock.Unlock()
+
+		objects, err := server.fetchChartsInStorage(c)
+
+		server.fetchedObjectsLock.Lock()
+		// flush every other consumer that also wanted the index
+		for _, foCh := range server.fetchedObjectsChans {
+			foCh <- fetchedObjects{objects, err}
+		}
+		server.fetchedObjectsChans = nil
+	}
+	server.fetchedObjectsLock.Unlock()
+
+	return ch
+}
+
+func (server *Server) regenerateRepositoryIndex(c *gin.Context, diff storage.ObjectSliceDiff, storageObjects []storage.Object) <-chan indexRegeneration {
+	ch := make(chan indexRegeneration, 1)
+
+	server.regenerationLock.Lock()
+	server.regeneratedIndexesChans = append(server.regeneratedIndexesChans, ch)
+
+	if len(server.regeneratedIndexesChans) == 1 {
+		server.regenerationLock.Unlock()
+
+		index, err := server.regenerateRepositoryIndexWorker(c, diff, storageObjects)
+
+		server.regenerationLock.Lock()
+		for _, riCh := range server.regeneratedIndexesChans {
+			riCh <- indexRegeneration{index, err}
+		}
+		server.regeneratedIndexesChans = nil
+	}
+	server.regenerationLock.Unlock()
+
+	return ch
+}
+
+/*
+syncRepositoryIndex is the workhorse of maintaining a coherent index cache. It is optimized for multiple requests
+comming in a short period. When two requests for the backing store arrive, only the first is served, and other consumers receive the
+result of this request. This allows very fast updates in constant time. See getChartList() and regenerateRepositoryIndex().
+*/
+func (server *Server) syncRepositoryIndex(c *gin.Context) (*repo.Index, error) {
+	fo := <-server.getChartList(c)
+
+	if fo.err != nil {
+		return nil, fo.err
+	}
+
+	diff := storage.GetObjectSliceDiff(server.StorageCache, fo.objects)
+
+	// return fast if no changes
+	if !diff.Change {
+		return server.RepositoryIndex, nil
+	}
+
+	ir := <-server.regenerateRepositoryIndex(c, diff, fo.objects)
+
+	return ir.index, ir.err
+}
+
+func (server *Server) fetchChartsInStorage(c *gin.Context) ([]storage.Object, error) {
+	server.Logger.Debugc(c, "Fetching chart list from storage")
+	allObjects, err := server.StorageBackend.ListObjects()
+	if err != nil {
+		return []storage.Object{}, err
+	}
+
+	// filter out storage objects that dont have extension used for chart packages (.tgz)
+	filteredObjects := []storage.Object{}
+	for _, object := range allObjects {
+		if object.HasExtension(repo.ChartPackageFileExtension) {
+			filteredObjects = append(filteredObjects, object)
+		}
+	}
+
+	return filteredObjects, nil
+}
+
+func (server *Server) regenerateRepositoryIndexWorker(c *gin.Context, diff storage.ObjectSliceDiff, storageObjects []storage.Object) (*repo.Index, error) {
+	server.Logger.Debugc(c, "Regenerating index.yaml")
+	index := &repo.Index{
+		IndexFile: server.RepositoryIndex.IndexFile,
+		Raw:       server.RepositoryIndex.Raw,
+		ChartURL:  server.RepositoryIndex.ChartURL,
+	}
+
+	for _, object := range diff.Removed {
+		err := server.removeIndexObject(c, index, object)
+		if err != nil {
+			return nil, err
+		}
+	}
+
+	for _, object := range diff.Updated {
+		err := server.updateIndexObject(c, index, object)
+		if err != nil {
+			return nil, err
+		}
+	}
+
+	// Parallelize retrieval of added objects to improve speed
+	err := server.addIndexObjectsAsync(c, index, diff.Added)
+	if err != nil {
+		return nil, err
+	}
+
+	err = index.Regenerate()
+	if err != nil {
+		return nil, err
+	}
+
+	// It is very important that these two stay in sync as they reflect the same reality. StorageCache serves
+	// as object modification time cache, and RepositoryIndex is the canonical cached index.
+	server.RepositoryIndex = index
+	server.StorageCache = storageObjects
+
+	server.Logger.Debugc(c, "index.yaml regenerated")
+	return index, nil
+}
+
+func (server *Server) removeIndexObject(c *gin.Context, index *repo.Index, object storage.Object) error {
+	chartVersion, err := server.getObjectChartVersion(object, false)
+	if err != nil {
+		return server.checkInvalidChartPackageError(c, object, err, "removed")
+	}
+	server.Logger.Debugc(c, "Removing chart from index",
+		"name", chartVersion.Name,
+		"version", chartVersion.Version,
+	)
+	index.RemoveEntry(chartVersion)
+	return nil
+}
+
+func (server *Server) updateIndexObject(c *gin.Context, index *repo.Index, object storage.Object) error {
+	chartVersion, err := server.getObjectChartVersion(object, true)
+	if err != nil {
+		return server.checkInvalidChartPackageError(c, object, err, "updated")
+	}
+	server.Logger.Debugc(c, "Updating chart in index",
+		"name", chartVersion.Name,
+		"version", chartVersion.Version,
+	)
+	index.UpdateEntry(chartVersion)
+	return nil
+}
+
+func (server *Server) addIndexObjectsAsync(c *gin.Context, index *repo.Index, objects []storage.Object) error {
+	numObjects := len(objects)
+	if numObjects == 0 {
+		return nil
+	}
+
+	server.Logger.Debugc(c, "Loading charts packages from storage (this could take awhile)",
+		"total", numObjects,
+	)
+
+	type cvResult struct {
+		cv  *helm_repo.ChartVersion
+		err error
+	}
+
+	cvChan := make(chan cvResult)
+
+	// Provide a mechanism to short-circuit object downloads in case of error
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	for _, object := range objects {
+		go func(o storage.Object) {
+			select {
+			case <-ctx.Done():
+				return
+			default:
+				chartVersion, err := server.getObjectChartVersion(o, true)
+				if err != nil {
+					err = server.checkInvalidChartPackageError(c, o, err, "added")
+				}
+				if err != nil {
+					cancel()
+				}
+				cvChan <- cvResult{chartVersion, err}
+			}
+		}(object)
+	}
+
+	for validCount := 0; validCount < numObjects; validCount++ {
+		cvRes := <-cvChan
+		if cvRes.err != nil {
+			return cvRes.err
+		}
+		if cvRes.cv == nil {
+			continue
+		}
+		server.Logger.Debugc(c, "Adding chart to index",
+			"name", cvRes.cv.Name,
+			"version", cvRes.cv.Version,
+		)
+		index.AddEntry(cvRes.cv)
+	}
+
+	return nil
+}
+
+func (server *Server) getObjectChartVersion(object storage.Object, load bool) (*helm_repo.ChartVersion, error) {
+	if load {
+		var err error
+		object, err = server.StorageBackend.GetObject(object.Path)
+		if err != nil {
+			return nil, err
+		}
+		if len(object.Content) == 0 {
+			return nil, repo.ErrorInvalidChartPackage
+		}
+	}
+	return repo.ChartVersionFromStorageObject(object)
+}
+
+func (server *Server) checkInvalidChartPackageError(c *gin.Context, object storage.Object, err error, action string) error {
+	if err == repo.ErrorInvalidChartPackage {
+		server.Logger.Warnc(c, "Invalid package in storage",
+			"action", action,
+			"package", object.Path,
+		)
+		return nil
+	}
+	return err
+}

--- a/pkg/chartmuseum/handlers.go
+++ b/pkg/chartmuseum/handlers.go
@@ -30,7 +30,7 @@ type (
 )
 
 func (server *Server) getIndexFileRequestHandler(c *gin.Context) {
-	index, err := server.syncRepositoryIndex(c.MustGet("RequestID").(string))
+	index, err := server.syncRepositoryIndex(c.MustGet("RequestCount").(string))
 	if err != nil {
 		c.JSON(500, errorResponse(err))
 		return
@@ -39,7 +39,7 @@ func (server *Server) getIndexFileRequestHandler(c *gin.Context) {
 }
 
 func (server *Server) getAllChartsRequestHandler(c *gin.Context) {
-	index, err := server.syncRepositoryIndex(c.MustGet("RequestID").(string))
+	index, err := server.syncRepositoryIndex(c.MustGet("RequestCount").(string))
 	if err != nil {
 		c.JSON(500, errorResponse(err))
 		return
@@ -49,7 +49,7 @@ func (server *Server) getAllChartsRequestHandler(c *gin.Context) {
 
 func (server *Server) getChartRequestHandler(c *gin.Context) {
 	name := c.Param("name")
-	index, err := server.syncRepositoryIndex(c.MustGet("RequestID").(string))
+	index, err := server.syncRepositoryIndex(c.MustGet("RequestCount").(string))
 	if err != nil {
 		c.JSON(500, errorResponse(err))
 		return
@@ -68,7 +68,7 @@ func (server *Server) getChartVersionRequestHandler(c *gin.Context) {
 	if version == "latest" {
 		version = ""
 	}
-	index, err := server.syncRepositoryIndex(c.MustGet("RequestID").(string))
+	index, err := server.syncRepositoryIndex(c.MustGet("RequestCount").(string))
 	if err != nil {
 		c.JSON(500, errorResponse(err))
 		return

--- a/pkg/chartmuseum/handlers.go
+++ b/pkg/chartmuseum/handlers.go
@@ -30,7 +30,8 @@ type (
 )
 
 func (server *Server) getIndexFileRequestHandler(c *gin.Context) {
-	index, err := server.syncRepositoryIndex(c)
+	log := server.contextLoggingFn(c)
+	index, err := server.syncRepositoryIndex(log)
 	if err != nil {
 		c.JSON(500, errorResponse(err))
 		return
@@ -39,7 +40,8 @@ func (server *Server) getIndexFileRequestHandler(c *gin.Context) {
 }
 
 func (server *Server) getAllChartsRequestHandler(c *gin.Context) {
-	index, err := server.syncRepositoryIndex(c)
+	log := server.contextLoggingFn(c)
+	index, err := server.syncRepositoryIndex(log)
 	if err != nil {
 		c.JSON(500, errorResponse(err))
 		return
@@ -49,7 +51,8 @@ func (server *Server) getAllChartsRequestHandler(c *gin.Context) {
 
 func (server *Server) getChartRequestHandler(c *gin.Context) {
 	name := c.Param("name")
-	index, err := server.syncRepositoryIndex(c)
+	log := server.contextLoggingFn(c)
+	index, err := server.syncRepositoryIndex(log)
 	if err != nil {
 		c.JSON(500, errorResponse(err))
 		return
@@ -68,7 +71,8 @@ func (server *Server) getChartVersionRequestHandler(c *gin.Context) {
 	if version == "latest" {
 		version = ""
 	}
-	index, err := server.syncRepositoryIndex(c)
+	log := server.contextLoggingFn(c)
+	index, err := server.syncRepositoryIndex(log)
 	if err != nil {
 		c.JSON(500, errorResponse(err))
 		return

--- a/pkg/chartmuseum/handlers.go
+++ b/pkg/chartmuseum/handlers.go
@@ -85,7 +85,7 @@ func (server *Server) deleteChartVersionRequestHandler(c *gin.Context) {
 	name := c.Param("name")
 	version := c.Param("version")
 	filename := repo.ChartPackageFilenameFromNameVersion(name, version)
-	server.Logger.Debugw("Deleting package from storage",
+	server.Logger.Debugc(c,"Deleting package from storage",
 		"package", filename,
 	)
 	err := server.StorageBackend.DeleteObject(filename)
@@ -177,7 +177,7 @@ func (server *Server) postPackageAndProvenanceRequestHandler(c *gin.Context) {
 	// At this point input is presumed valid, we now proceed to store it
 	var storedFiles []*packageOrProvenanceFile
 	for _, ppf := range ppFiles {
-		server.Logger.Debugw("Adding file to storage (form field)",
+		server.Logger.Debugc(c,"Adding file to storage (form field)",
 			"filename", ppf.filename,
 			"field", ppf.field,
 		)
@@ -221,7 +221,7 @@ func (server *Server) postPackageRequestHandler(c *gin.Context) {
 			return
 		}
 	}
-	server.Logger.Debugw("Adding package to storage",
+	server.Logger.Debugc(c,"Adding package to storage",
 		"package", filename,
 	)
 	err = server.StorageBackend.PutObject(filename, content)
@@ -250,7 +250,7 @@ func (server *Server) postProvenanceFileRequestHandler(c *gin.Context) {
 			return
 		}
 	}
-	server.Logger.Debugw("Adding provenance file to storage",
+	server.Logger.Debugc(c,"Adding provenance file to storage",
 		"provenance_file", filename,
 	)
 	err = server.StorageBackend.PutObject(filename, content)

--- a/pkg/chartmuseum/handlers.go
+++ b/pkg/chartmuseum/handlers.go
@@ -30,7 +30,7 @@ type (
 )
 
 func (server *Server) getIndexFileRequestHandler(c *gin.Context) {
-	index, err := server.syncRepositoryIndex(c.MustGet("RequestCount").(string))
+	index, err := server.syncRepositoryIndex(c)
 	if err != nil {
 		c.JSON(500, errorResponse(err))
 		return
@@ -39,7 +39,7 @@ func (server *Server) getIndexFileRequestHandler(c *gin.Context) {
 }
 
 func (server *Server) getAllChartsRequestHandler(c *gin.Context) {
-	index, err := server.syncRepositoryIndex(c.MustGet("RequestCount").(string))
+	index, err := server.syncRepositoryIndex(c)
 	if err != nil {
 		c.JSON(500, errorResponse(err))
 		return
@@ -49,7 +49,7 @@ func (server *Server) getAllChartsRequestHandler(c *gin.Context) {
 
 func (server *Server) getChartRequestHandler(c *gin.Context) {
 	name := c.Param("name")
-	index, err := server.syncRepositoryIndex(c.MustGet("RequestCount").(string))
+	index, err := server.syncRepositoryIndex(c)
 	if err != nil {
 		c.JSON(500, errorResponse(err))
 		return
@@ -68,7 +68,7 @@ func (server *Server) getChartVersionRequestHandler(c *gin.Context) {
 	if version == "latest" {
 		version = ""
 	}
-	index, err := server.syncRepositoryIndex(c.MustGet("RequestCount").(string))
+	index, err := server.syncRepositoryIndex(c)
 	if err != nil {
 		c.JSON(500, errorResponse(err))
 		return

--- a/pkg/chartmuseum/logging.go
+++ b/pkg/chartmuseum/logging.go
@@ -1,0 +1,107 @@
+package chartmuseum
+
+import (
+	"fmt"
+	"strconv"
+	"sync/atomic"
+	"time"
+
+	"github.com/gin-gonic/gin"
+	"go.uber.org/zap"
+	"go.uber.org/zap/zapcore"
+)
+
+type (
+	// Logger handles all logging from application
+	Logger struct {
+		*zap.SugaredLogger
+	}
+)
+
+// NewLogger creates a new Logger instance
+func NewLogger(json bool, debug bool) (*Logger, error) {
+	config := zap.NewDevelopmentConfig()
+	config.DisableStacktrace = true
+	config.Development = false
+	if json {
+		config.Encoding = "json"
+	} else {
+		config.EncoderConfig.EncodeLevel = zapcore.CapitalColorLevelEncoder
+	}
+	if !debug {
+		config.Level = zap.NewAtomicLevelAt(zap.InfoLevel)
+	}
+	logger, err := config.Build()
+	if err != nil {
+		return new(Logger), err
+	}
+	defer logger.Sync()
+	return &Logger{logger.Sugar()}, nil
+}
+
+// Debugc wraps Debugw provided by zap, adding data from gin request context
+func (logger *Logger) Debugc(c *gin.Context, msg string, keysAndValues ...interface{}) {
+	msg, keysAndValues = transformLogcArgs(c, msg, keysAndValues)
+	logger.Debugw(msg, keysAndValues...)
+}
+
+// Infoc wraps Infow provided by zap, adding data from gin request context
+func (logger *Logger) Infoc(c *gin.Context, msg string, keysAndValues ...interface{}) {
+	msg, keysAndValues = transformLogcArgs(c, msg, keysAndValues)
+	logger.Infow(msg, keysAndValues...)
+}
+
+// Warnc wraps Warnw provided by zap, adding data from gin request context
+func (logger *Logger) Warnc(c *gin.Context, msg string, keysAndValues ...interface{}) {
+	msg, keysAndValues = transformLogcArgs(c, msg, keysAndValues)
+	logger.Warnw(msg, keysAndValues...)
+}
+
+// Errorc wraps Errorw provided by zap, adding data from gin request context
+func (logger *Logger) Errorc(c *gin.Context, msg string, keysAndValues ...interface{}) {
+	msg, keysAndValues = transformLogcArgs(c, msg, keysAndValues)
+	logger.Errorw(msg, keysAndValues...)
+}
+
+// transformLogcArgs prefixes msg with RequestCount and adds RequestId to keysAndValues
+func transformLogcArgs(c *gin.Context, msg string, keysAndValues []interface{}) (string, []interface{}) {
+	if reqCount, exists := c.Get("RequestCount"); exists {
+		msg = fmt.Sprintf("[%s] %s", reqCount, msg)
+		keysAndValues = append(keysAndValues, "reqID", c.MustGet("RequestId"))
+	}
+	return msg, keysAndValues
+}
+
+func loggingMiddleware(logger *Logger) gin.HandlerFunc {
+	var requestCount int64
+	return func(c *gin.Context) {
+		reqCount := strconv.FormatInt(atomic.AddInt64(&requestCount, 1), 10)
+		c.Set("RequestCount", reqCount)
+
+		reqPath := c.Request.URL.Path
+		logger.Debugc(c, fmt.Sprintf("Incoming request: %s", reqPath))
+		start := time.Now()
+		c.Next()
+
+		msg := "Request served"
+		status := c.Writer.Status()
+
+		meta := []interface{}{
+			"path", reqPath,
+			"comment", c.Errors.ByType(gin.ErrorTypePrivate).String(),
+			"latency", time.Now().Sub(start),
+			"clientIP", c.ClientIP(),
+			"method", c.Request.Method,
+			"statusCode", status,
+		}
+
+		switch {
+		case status == 200 || status == 201:
+			logger.Infoc(c, msg, meta...)
+		case status == 404:
+			logger.Warnc(c, msg, meta...)
+		default:
+			logger.Errorc(c, msg, meta...)
+		}
+	}
+}

--- a/pkg/chartmuseum/server.go
+++ b/pkg/chartmuseum/server.go
@@ -100,7 +100,8 @@ func NewServer(options ServerOptions) (*Server, error) {
 	server.setRoutes(options.EnableAPI)
 
 	// prime the cache
-	_, err = server.syncRepositoryIndex(&gin.Context{})
+	log := server.contextLoggingFn(&gin.Context{})
+	_, err = server.syncRepositoryIndex(log)
 	return server, err
 }
 

--- a/pkg/chartmuseum/server.go
+++ b/pkg/chartmuseum/server.go
@@ -1,7 +1,6 @@
 package chartmuseum
 
 import (
-	"context"
 	"fmt"
 	"regexp"
 	"sync"
@@ -12,7 +11,6 @@ import (
 	"github.com/atarantini/ginrequestid"
 	"github.com/gin-gonic/gin"
 	"github.com/zsais/go-gin-prometheus"
-	helm_repo "k8s.io/helm/pkg/repo"
 )
 
 type (
@@ -66,15 +64,6 @@ type (
 	}
 )
 
-func mapURLWithParamsBackToRouteTemplate(c *gin.Context) string {
-	url := c.Request.URL.String()
-	for _, p := range c.Params {
-		re := regexp.MustCompile(fmt.Sprintf(`(^.*?)/\b%s\b(.*$)`, regexp.QuoteMeta(p.Value)))
-		url = re.ReplaceAllString(url, fmt.Sprintf(`$1/:%s$2`, p.Key))
-	}
-	return url
-}
-
 // NewRouter creates a new Router instance
 func NewRouter(logger *Logger, username string, password string, enableMetrics bool) *Router {
 	gin.SetMode(gin.ReleaseMode)
@@ -87,9 +76,6 @@ func NewRouter(logger *Logger, username string, password string, enableMetrics b
 	}
 	if enableMetrics {
 		p := ginprometheus.NewPrometheus("chartmuseum")
-		// For every route containing parameters (e.g. `/charts/:filename`, `/api/charts/:name/:version`, etc)
-		// the actual parameter values will be replaced by their name, to minimize the cardinality of the
-		// `chartmuseum_requests_total{url=..}` Prometheus counter.
 		p.ReqCntURLLabelMappingFn = mapURLWithParamsBackToRouteTemplate
 		p.Use(engine)
 	}
@@ -139,241 +125,17 @@ func (server *Server) Listen(port int) {
 	}
 }
 
-// getChartList fetches from the server and accumulates concurrent requests to be fulfilled all at once.
-func (server *Server) getChartList(c *gin.Context) <-chan fetchedObjects {
-	ch := make(chan fetchedObjects, 1)
-
-	server.fetchedObjectsLock.Lock()
-	server.fetchedObjectsChans = append(server.fetchedObjectsChans, ch)
-
-	if len(server.fetchedObjectsChans) == 1 {
-		// this unlock is wanted, while fetching the list, allow other channeled requests to be added
-		server.fetchedObjectsLock.Unlock()
-
-		objects, err := server.fetchChartsInStorage(c)
-
-		server.fetchedObjectsLock.Lock()
-		// flush every other consumer that also wanted the index
-		for _, foCh := range server.fetchedObjectsChans {
-			foCh <- fetchedObjects{objects, err}
-		}
-		server.fetchedObjectsChans = nil
-	}
-	server.fetchedObjectsLock.Unlock()
-
-	return ch
-}
-
-func (server *Server) regenerateRepositoryIndex(c *gin.Context, diff storage.ObjectSliceDiff, storageObjects []storage.Object) <-chan indexRegeneration {
-	ch := make(chan indexRegeneration, 1)
-
-	server.regenerationLock.Lock()
-	server.regeneratedIndexesChans = append(server.regeneratedIndexesChans, ch)
-
-	if len(server.regeneratedIndexesChans) == 1 {
-		server.regenerationLock.Unlock()
-
-		index, err := server.regenerateRepositoryIndexWorker(c, diff, storageObjects)
-
-		server.regenerationLock.Lock()
-		for _, riCh := range server.regeneratedIndexesChans {
-			riCh <- indexRegeneration{index, err}
-		}
-		server.regeneratedIndexesChans = nil
-	}
-	server.regenerationLock.Unlock()
-
-	return ch
-}
-
 /*
-syncRepositoryIndex is the workhorse of maintaining a coherent index cache. It is optimized for multiple requests
-comming in a short period. When two requests for the backing store arrive, only the first is served, and other consumers receive the
-result of this request. This allows very fast updates in constant time. See getChartList() and regenerateRepositoryIndex().
+mapURLWithParamsBackToRouteTemplate is a valid ginprometheus ReqCntURLLabelMappingFn.
+For every route containing parameters (e.g. `/charts/:filename`, `/api/charts/:name/:version`, etc)
+the actual parameter values will be replaced by their name, to minimize the cardinality of the
+`chartmuseum_requests_total{url=..}` Prometheus counter.
 */
-func (server *Server) syncRepositoryIndex(c *gin.Context) (*repo.Index, error) {
-	fo := <-server.getChartList(c)
-
-	if fo.err != nil {
-		return nil, fo.err
+func mapURLWithParamsBackToRouteTemplate(c *gin.Context) string {
+	url := c.Request.URL.String()
+	for _, p := range c.Params {
+		re := regexp.MustCompile(fmt.Sprintf(`(^.*?)/\b%s\b(.*$)`, regexp.QuoteMeta(p.Value)))
+		url = re.ReplaceAllString(url, fmt.Sprintf(`$1/:%s$2`, p.Key))
 	}
-
-	diff := storage.GetObjectSliceDiff(server.StorageCache, fo.objects)
-
-	// return fast if no changes
-	if !diff.Change {
-		return server.RepositoryIndex, nil
-	}
-
-	ir := <-server.regenerateRepositoryIndex(c, diff, fo.objects)
-
-	return ir.index, ir.err
-}
-
-func (server *Server) fetchChartsInStorage(c *gin.Context) ([]storage.Object, error) {
-	server.Logger.Debugc(c, "Fetching chart list from storage")
-	allObjects, err := server.StorageBackend.ListObjects()
-	if err != nil {
-		return []storage.Object{}, err
-	}
-
-	// filter out storage objects that dont have extension used for chart packages (.tgz)
-	filteredObjects := []storage.Object{}
-	for _, object := range allObjects {
-		if object.HasExtension(repo.ChartPackageFileExtension) {
-			filteredObjects = append(filteredObjects, object)
-		}
-	}
-
-	return filteredObjects, nil
-}
-
-func (server *Server) regenerateRepositoryIndexWorker(c *gin.Context, diff storage.ObjectSliceDiff, storageObjects []storage.Object) (*repo.Index, error) {
-	server.Logger.Debugc(c, "Regenerating index.yaml")
-	index := &repo.Index{
-		IndexFile: server.RepositoryIndex.IndexFile,
-		Raw:       server.RepositoryIndex.Raw,
-		ChartURL:  server.RepositoryIndex.ChartURL,
-	}
-
-	for _, object := range diff.Removed {
-		err := server.removeIndexObject(c, index, object)
-		if err != nil {
-			return nil, err
-		}
-	}
-
-	for _, object := range diff.Updated {
-		err := server.updateIndexObject(c, index, object)
-		if err != nil {
-			return nil, err
-		}
-	}
-
-	// Parallelize retrieval of added objects to improve speed
-	err := server.addIndexObjectsAsync(c, index, diff.Added)
-	if err != nil {
-		return nil, err
-	}
-
-	err = index.Regenerate()
-	if err != nil {
-		return nil, err
-	}
-
-	// It is very important that these two stay in sync as they reflect the same reality. StorageCache serves
-	// as object modification time cache, and RepositoryIndex is the canonical cached index.
-	server.RepositoryIndex = index
-	server.StorageCache = storageObjects
-
-	server.Logger.Debugc(c, "index.yaml regenerated")
-	return index, nil
-}
-
-func (server *Server) removeIndexObject(c *gin.Context, index *repo.Index, object storage.Object) error {
-	chartVersion, err := server.getObjectChartVersion(object, false)
-	if err != nil {
-		return server.checkInvalidChartPackageError(c, object, err, "removed")
-	}
-	server.Logger.Debugc(c, "Removing chart from index",
-		"name", chartVersion.Name,
-		"version", chartVersion.Version,
-	)
-	index.RemoveEntry(chartVersion)
-	return nil
-}
-
-func (server *Server) updateIndexObject(c *gin.Context, index *repo.Index, object storage.Object) error {
-	chartVersion, err := server.getObjectChartVersion(object, true)
-	if err != nil {
-		return server.checkInvalidChartPackageError(c, object, err, "updated")
-	}
-	server.Logger.Debugc(c, "Updating chart in index",
-		"name", chartVersion.Name,
-		"version", chartVersion.Version,
-	)
-	index.UpdateEntry(chartVersion)
-	return nil
-}
-
-func (server *Server) addIndexObjectsAsync(c *gin.Context, index *repo.Index, objects []storage.Object) error {
-	numObjects := len(objects)
-	if numObjects == 0 {
-		return nil
-	}
-
-	server.Logger.Debugc(c, "Loading charts packages from storage (this could take awhile)",
-		"total", numObjects,
-	)
-
-	type cvResult struct {
-		cv  *helm_repo.ChartVersion
-		err error
-	}
-
-	cvChan := make(chan cvResult)
-
-	// Provide a mechanism to short-circuit object downloads in case of error
-	ctx, cancel := context.WithCancel(context.Background())
-	defer cancel()
-
-	for _, object := range objects {
-		go func(o storage.Object) {
-			select {
-			case <-ctx.Done():
-				return
-			default:
-				chartVersion, err := server.getObjectChartVersion(o, true)
-				if err != nil {
-					err = server.checkInvalidChartPackageError(c, o, err, "added")
-				}
-				if err != nil {
-					cancel()
-				}
-				cvChan <- cvResult{chartVersion, err}
-			}
-		}(object)
-	}
-
-	for validCount := 0; validCount < numObjects; validCount++ {
-		cvRes := <-cvChan
-		if cvRes.err != nil {
-			return cvRes.err
-		}
-		if cvRes.cv == nil {
-			continue
-		}
-		server.Logger.Debugc(c, "Adding chart to index",
-			"name", cvRes.cv.Name,
-			"version", cvRes.cv.Version,
-		)
-		index.AddEntry(cvRes.cv)
-	}
-
-	return nil
-}
-
-func (server *Server) getObjectChartVersion(object storage.Object, load bool) (*helm_repo.ChartVersion, error) {
-	if load {
-		var err error
-		object, err = server.StorageBackend.GetObject(object.Path)
-		if err != nil {
-			return nil, err
-		}
-		if len(object.Content) == 0 {
-			return nil, repo.ErrorInvalidChartPackage
-		}
-	}
-	return repo.ChartVersionFromStorageObject(object)
-}
-
-func (server *Server) checkInvalidChartPackageError(c *gin.Context, object storage.Object, err error, action string) error {
-	if err == repo.ErrorInvalidChartPackage {
-		server.Logger.Warnc(c, "Invalid package in storage",
-			"action", action,
-			"package", object.Path,
-		)
-		return nil
-	}
-	return err
+	return url
 }

--- a/pkg/chartmuseum/server.go
+++ b/pkg/chartmuseum/server.go
@@ -12,6 +12,7 @@ import (
 	"github.com/kubernetes-helm/chartmuseum/pkg/repo"
 	"github.com/kubernetes-helm/chartmuseum/pkg/storage"
 
+	"github.com/atarantini/ginrequestid"
 	"github.com/gin-gonic/gin"
 	"github.com/zsais/go-gin-prometheus"
 	"go.uber.org/zap"
@@ -108,7 +109,7 @@ func mapURLWithParamsBackToRouteTemplate(c *gin.Context) string {
 func NewRouter(logger *Logger, username string, password string, enableMetrics bool) *Router {
 	gin.SetMode(gin.ReleaseMode)
 	engine := gin.New()
-	engine.Use(loggingMiddleware(logger), gin.Recovery())
+	engine.Use(ginrequestid.RequestId(), loggingMiddleware(logger), gin.Recovery())
 	if username != "" && password != "" {
 		users := make(map[string]string)
 		users[username] = password
@@ -187,6 +188,7 @@ func loggingMiddleware(logger *Logger) gin.HandlerFunc {
 			"clientIP", c.ClientIP(),
 			"method", c.Request.Method,
 			"statusCode", status,
+			"reqID", c.MustGet("RequestId"),
 		}
 
 		switch {

--- a/pkg/chartmuseum/server.go
+++ b/pkg/chartmuseum/server.go
@@ -53,15 +53,6 @@ type (
 		ChartPostFormFieldName string
 		ProvPostFormFieldName  string
 	}
-
-	fetchedObjects struct {
-		objects []storage.Object
-		err     error
-	}
-	indexRegeneration struct {
-		index *repo.Index
-		err   error
-	}
 )
 
 // NewRouter creates a new Router instance

--- a/pkg/chartmuseum/server_test.go
+++ b/pkg/chartmuseum/server_test.go
@@ -132,41 +132,43 @@ func (suite *ServerTestSuite) TearDownSuite() {
 }
 
 func (suite *ServerTestSuite) TestRegenerateRepositoryIndex() {
-	objects, err := suite.Server.fetchChartsInStorage("test")
+	c := &gin.Context{}
+
+	objects, err := suite.Server.fetchChartsInStorage(c)
 	diff := storage.GetObjectSliceDiff(suite.Server.StorageCache, objects)
-	_, err = suite.Server.regenerateRepositoryIndexWorker(diff, objects, "test")
+	_, err = suite.Server.regenerateRepositoryIndexWorker(c, diff, objects)
 	suite.Nil(err, "no error regenerating repo index")
 
 	newtime := time.Now().Add(1 * time.Hour)
 	err = os.Chtimes(suite.TestTarballFilename, newtime, newtime)
 	suite.Nil(err, "no error changing modtime on temp file")
 
-	objects, err = suite.Server.fetchChartsInStorage("test")
+	objects, err = suite.Server.fetchChartsInStorage(c)
 	diff = storage.GetObjectSliceDiff(suite.Server.StorageCache, objects)
-	_, err = suite.Server.regenerateRepositoryIndexWorker(diff, objects, "test")
+	_, err = suite.Server.regenerateRepositoryIndexWorker(c, diff, objects)
 	suite.Nil(err, "no error regenerating repo index with tarball updated")
 
 	brokenTarballFilename := pathutil.Join(suite.TempDirectory, "brokenchart.tgz")
 	destFile, err := os.Create(brokenTarballFilename)
 	suite.Nil(err, "no error creating new broken tarball in temp dir")
 	defer destFile.Close()
-	objects, err = suite.Server.fetchChartsInStorage("test")
+	objects, err = suite.Server.fetchChartsInStorage(c)
 	diff = storage.GetObjectSliceDiff(suite.Server.StorageCache, objects)
-	_, err = suite.Server.regenerateRepositoryIndexWorker(diff, objects, "test")
+	_, err = suite.Server.regenerateRepositoryIndexWorker(c, diff, objects)
 	suite.Nil(err, "error not returned with broken tarball added")
 
 	err = os.Chtimes(brokenTarballFilename, newtime, newtime)
 	suite.Nil(err, "no error changing modtime on broken tarball")
-	objects, err = suite.Server.fetchChartsInStorage("test")
+	objects, err = suite.Server.fetchChartsInStorage(c)
 	diff = storage.GetObjectSliceDiff(suite.Server.StorageCache, objects)
-	_, err = suite.Server.regenerateRepositoryIndexWorker(diff, objects, "test")
+	_, err = suite.Server.regenerateRepositoryIndexWorker(c, diff, objects)
 	suite.Nil(err, "error not returned with broken tarball updated")
 
 	err = os.Remove(brokenTarballFilename)
 	suite.Nil(err, "no error removing broken tarball")
-	objects, err = suite.Server.fetchChartsInStorage("test")
+	objects, err = suite.Server.fetchChartsInStorage(c)
 	diff = storage.GetObjectSliceDiff(suite.Server.StorageCache, objects)
-	_, err = suite.Server.regenerateRepositoryIndexWorker(diff, objects, "test")
+	_, err = suite.Server.regenerateRepositoryIndexWorker(c, diff, objects)
 	suite.Nil(err, "error not returned with broken tarball removed")
 }
 

--- a/pkg/chartmuseum/server_test.go
+++ b/pkg/chartmuseum/server_test.go
@@ -132,43 +132,43 @@ func (suite *ServerTestSuite) TearDownSuite() {
 }
 
 func (suite *ServerTestSuite) TestRegenerateRepositoryIndex() {
-	c := &gin.Context{}
+	log := suite.Server.contextLoggingFn(&gin.Context{})
 
-	objects, err := suite.Server.fetchChartsInStorage(c)
+	objects, err := suite.Server.fetchChartsInStorage(log)
 	diff := storage.GetObjectSliceDiff(suite.Server.StorageCache, objects)
-	_, err = suite.Server.regenerateRepositoryIndexWorker(c, diff, objects)
+	_, err = suite.Server.regenerateRepositoryIndexWorker(log, diff, objects)
 	suite.Nil(err, "no error regenerating repo index")
 
 	newtime := time.Now().Add(1 * time.Hour)
 	err = os.Chtimes(suite.TestTarballFilename, newtime, newtime)
 	suite.Nil(err, "no error changing modtime on temp file")
 
-	objects, err = suite.Server.fetchChartsInStorage(c)
+	objects, err = suite.Server.fetchChartsInStorage(log)
 	diff = storage.GetObjectSliceDiff(suite.Server.StorageCache, objects)
-	_, err = suite.Server.regenerateRepositoryIndexWorker(c, diff, objects)
+	_, err = suite.Server.regenerateRepositoryIndexWorker(log, diff, objects)
 	suite.Nil(err, "no error regenerating repo index with tarball updated")
 
 	brokenTarballFilename := pathutil.Join(suite.TempDirectory, "brokenchart.tgz")
 	destFile, err := os.Create(brokenTarballFilename)
 	suite.Nil(err, "no error creating new broken tarball in temp dir")
 	defer destFile.Close()
-	objects, err = suite.Server.fetchChartsInStorage(c)
+	objects, err = suite.Server.fetchChartsInStorage(log)
 	diff = storage.GetObjectSliceDiff(suite.Server.StorageCache, objects)
-	_, err = suite.Server.regenerateRepositoryIndexWorker(c, diff, objects)
+	_, err = suite.Server.regenerateRepositoryIndexWorker(log, diff, objects)
 	suite.Nil(err, "error not returned with broken tarball added")
 
 	err = os.Chtimes(brokenTarballFilename, newtime, newtime)
 	suite.Nil(err, "no error changing modtime on broken tarball")
-	objects, err = suite.Server.fetchChartsInStorage(c)
+	objects, err = suite.Server.fetchChartsInStorage(log)
 	diff = storage.GetObjectSliceDiff(suite.Server.StorageCache, objects)
-	_, err = suite.Server.regenerateRepositoryIndexWorker(c, diff, objects)
+	_, err = suite.Server.regenerateRepositoryIndexWorker(log, diff, objects)
 	suite.Nil(err, "error not returned with broken tarball updated")
 
 	err = os.Remove(brokenTarballFilename)
 	suite.Nil(err, "no error removing broken tarball")
-	objects, err = suite.Server.fetchChartsInStorage(c)
+	objects, err = suite.Server.fetchChartsInStorage(log)
 	diff = storage.GetObjectSliceDiff(suite.Server.StorageCache, objects)
-	_, err = suite.Server.regenerateRepositoryIndexWorker(c, diff, objects)
+	_, err = suite.Server.regenerateRepositoryIndexWorker(log, diff, objects)
 	suite.Nil(err, "error not returned with broken tarball removed")
 }
 

--- a/pkg/chartmuseum/server_test.go
+++ b/pkg/chartmuseum/server_test.go
@@ -178,6 +178,10 @@ func (suite *ServerTestSuite) TestRoutes() {
 	res = suite.doRequest("normal", "GET", "/charts/mychart-0.1.0.tgz", nil, "")
 	suite.Equal(200, res.Status(), "200 GET /charts/mychart-0.1.0.tgz")
 
+	// Issue #21
+	suite.NotEqual("", res.Header().Get("X-Request-Id"), "X-Request-Id header is present")
+	suite.Equal("", res.Header().Get("X-Blah-Blah-Blah"), "X-Blah-Blah-Blah header is not present")
+
 	res = suite.doRequest("normal", "GET", "/charts/mychart-0.1.0.tgz.prov", nil, "")
 	suite.Equal(200, res.Status(), "200 GET /charts/mychart-0.1.0.tgz.prov")
 


### PR DESCRIPTION
Implementation of proposal discussed in #21.

The `X-Request-Id` header is added to every response, courtesy of [atarantini/ginrequestid](https://github.com/atarantini/ginrequestid) middleware.

Added new methods to the Logger type, suffixed with the letter "c", that take gin context as an argument, automatically adding request id to each log line associated with a request (as well as prefixing log message with local request count @davidovich).

Also, server.go was starting to grow, so I moved some stuff into new files logging.go and cache.go.