### PR TITLE
Add Azure Blob storage backend

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@
 [![GoDoc](https://godoc.org/github.com/kubernetes-helm/chartmuseum?status.svg)](https://godoc.org/github.com/kubernetes-helm/chartmuseum)
 <sub>**_"Preserve your precious artifacts... in the cloud!"_**<sub>
 
-*ChartMuseum* is an open-source **[Helm Chart Repository](https://github.com/kubernetes/helm/blob/master/docs/chart_repository.md)** written in Go (Golang), with support for cloud storage backends, including [Google Cloud Storage](https://cloud.google.com/storage/) and [Amazon S3](https://aws.amazon.com/s3/).
+*ChartMuseum* is an open-source **[Helm Chart Repository](https://github.com/kubernetes/helm/blob/master/docs/chart_repository.md)** written in Go (Golang), with support for cloud storage backends, including [Google Cloud Storage](https://cloud.google.com/storage/), [Amazon S3](https://aws.amazon.com/s3/), and [Azure Blob Storage](https://azure.microsoft.com/en-us/services/storage/blobs/).
 
 Works as a valid Helm Chart Repository, and also provides an API for uploading new chart packages to storage etc.
 
@@ -133,6 +133,18 @@ chartmuseum --debug --port=8080 \
   --storage="google" \
   --storage-google-bucket="my-gcs-bucket" \
   --storage-google-prefix=""
+```
+
+#### Using with Azure Blob Storage
+
+Make sure your environment is properly setup to access `my-storage-account`
+
+```bash
+chartmuseum --debug --port=8080 \
+  --storage="azure" \
+  --storage-azure-name="my-storage-account" \
+  --storage-azure-key="<...>" \
+  --storage-azure-container="charts"
 ```
 
 #### Using with local filesystem storage

--- a/cmd/chartmuseum/main.go
+++ b/cmd/chartmuseum/main.go
@@ -81,6 +81,8 @@ func backendFromContext(c *cli.Context) storage.Backend {
 		backend = amazonBackendFromContext(c)
 	case "google":
 		backend = googleBackendFromContext(c)
+	case "azure":
+		backend = azureBackendFromContext(c)
 	default:
 		crash("Unsupported storage backend: ", storageFlag)
 	}
@@ -114,6 +116,15 @@ func googleBackendFromContext(c *cli.Context) storage.Backend {
 	return storage.Backend(storage.NewGoogleCSBackend(
 		c.String("storage-google-bucket"),
 		c.String("storage-google-prefix"),
+	))
+}
+
+func azureBackendFromContext(c *cli.Context) storage.Backend {
+	crashIfContextMissingFlags(c, []string{"storage-azure-name", "storage-azure-key", "storage-azure-container"})
+	return storage.Backend(storage.NewAzureBlobBackend(
+		c.String("storage-azure-name"),
+		c.String("storage-azure-key"),
+		c.String("storage-azure-container"),
 	))
 }
 
@@ -230,6 +241,21 @@ var cliFlags = []cli.Flag{
 		Name:   "storage-google-prefix",
 		Usage:  "prefix to store charts for --storage-google-bucket",
 		EnvVar: "STORAGE_GOOGLE_PREFIX",
+	},
+	cli.StringFlag{
+		Name:   "storage-azure-name",
+		Usage:  "name to store charts for --storage-azure-name",
+		EnvVar: "STORAGE_AZURE_NAME",
+	},
+	cli.StringFlag{
+		Name:   "storage-azure-key",
+		Usage:  "key to store charts for --storage-azure-key",
+		EnvVar: "STORAGE_AZURE_KEY",
+	},
+	cli.StringFlag{
+		Name:   "storage-azure-container",
+		Usage:  "container to store charts for --storage-azure-container",
+		EnvVar: "STORAGE_AZURE_KEY",
 	},
 	cli.StringFlag{
 		Name:   "chart-post-form-field-name",

--- a/cmd/chartmuseum/main.go
+++ b/cmd/chartmuseum/main.go
@@ -255,7 +255,7 @@ var cliFlags = []cli.Flag{
 	cli.StringFlag{
 		Name:   "storage-azure-container",
 		Usage:  "container to store charts for --storage-azure-container",
-		EnvVar: "STORAGE_AZURE_KEY",
+		EnvVar: "STORAGE_AZURE_CONTAINER",
 	},
 	cli.StringFlag{
 		Name:   "chart-post-form-field-name",

--- a/glide.yaml
+++ b/glide.yaml
@@ -16,6 +16,7 @@ import:
 - package: github.com/atarantini/ginrequestid
   version: a432ade0ce478903613da1372cb5a62914cfe532
 
+# Used by Azure Blob storage backend
 - package: github.com/Azure/go-autorest
   version: v9.4.1
 - package: github.com/satori/uuid

--- a/glide.yaml
+++ b/glide.yaml
@@ -16,6 +16,15 @@ import:
 - package: github.com/atarantini/ginrequestid
   version: a432ade0ce478903613da1372cb5a62914cfe532
 
+- package: github.com/Azure/go-autorest
+  version: v9.4.1
+- package: github.com/satori/uuid
+  version: v1.1.0
+- package: github.com/Azure/azure-sdk-for-go
+  version: v11.2.2-beta
+  subpackages:
+  - storage
+
 # these ones are srsly a pain in da butt...
 # all needed to get cloud.google.com/go/storage to work
 - package: cloud.google.com/go

--- a/pkg/storage/azure.go
+++ b/pkg/storage/azure.go
@@ -88,8 +88,6 @@ func (b AzureBlobBackend) GetObject(path string) (Object, error) {
 		return object, err
 	}
 	
-	// defer readCloser.Close()
-
 	content, err = ioutil.ReadAll(readCloser)
 
 	if err != nil {

--- a/pkg/storage/azure.go
+++ b/pkg/storage/azure.go
@@ -1,0 +1,128 @@
+package storage
+
+import (
+	"errors"
+	"io/ioutil"
+	"time"
+
+	"github.com/Azure/azure-sdk-for-go/storage"
+)
+
+// AzureBlobBackend is a storage backend for Amazon S3
+type AzureBlobBackend struct {
+	Container  *storage.Container
+}
+
+// NewAzureBlobBackend creates a new instance of AzureBlobBackend
+func NewAzureBlobBackend(accountName string, accountKey string, containerName string) *AzureBlobBackend {
+	client, err := storage.NewBasicClient(accountName, accountKey)
+
+	var containerRef *storage.Container;
+
+	if (err == nil) {
+		blobClient := client.GetBlobService()
+		containerRef = blobClient.GetContainerReference(containerName)
+	}
+
+	b := &AzureBlobBackend{
+		Container: containerRef,
+	}
+
+	return b
+}
+
+// ListObjects lists all objects in Amazon S3 bucket, at prefix
+func (b AzureBlobBackend) ListObjects() ([]Object, error) {
+	
+	var objects []Object
+
+	if (b.Container == nil) {
+		return objects, errors.New("Unable to obtain a container reference.")
+	}
+
+	var params storage.ListBlobsParameters
+	response, err := b.Container.ListBlobs(params)
+
+	for _, blob := range response.Blobs {
+		err = blob.GetProperties(nil);
+
+		if (err != nil) {
+			return objects, err;
+		}
+
+		object := Object {
+			Path: blob.Name,
+			Content: []byte{},
+			LastModified: time.Time(blob.Properties.LastModified),
+		}
+
+		objects = append(objects, object)
+	}
+	return objects, nil
+}
+
+// GetObject retrieves an object from Amazon S3 bucket, at prefix
+func (b AzureBlobBackend) GetObject(path string) (Object, error) {
+	var object Object
+	object.Path = path
+	var content []byte
+
+	if (b.Container == nil) {
+		return object, errors.New("Unable to obtain a container reference.")
+	}
+
+	blobReference := b.Container.GetBlobReference(path)
+	exists, err := blobReference.Exists()
+
+	if err != nil {
+		return object, err
+	}
+
+	if !exists {
+		return object, errors.New("Object does not exist.")
+	}
+
+	readCloser, err := blobReference.Get(nil)
+	
+	if err != nil {
+		return object, err
+	}
+	
+	// defer readCloser.Close()
+
+	content, err = ioutil.ReadAll(readCloser)
+
+	if err != nil {
+		return object, err
+	}
+	object.Content = content
+	err = blobReference.GetProperties(nil)
+	object.LastModified = time.Time(blobReference.Properties.LastModified)
+	return object, nil
+}
+
+// PutObject uploads an object to Amazon S3 bucket, at prefix
+func (b AzureBlobBackend) PutObject(path string, content []byte) error {
+	if (b.Container == nil) {
+		return errors.New("Unable to obtain a container reference.")
+	}
+
+	blobReference := b.Container.GetBlobReference(path)
+
+	err := blobReference.PutAppendBlob(nil)
+
+	if (err == nil) {
+		err = blobReference.AppendBlock(content, nil)
+	}
+
+	return err
+}
+
+// DeleteObject removes an object from Amazon S3 bucket, at prefix
+func (b AzureBlobBackend) DeleteObject(path string) error {
+	blobReference := b.Container.GetBlobReference(path)
+
+	_, err := blobReference.DeleteIfExists(nil);
+
+	return err
+}

--- a/pkg/storage/azure.go
+++ b/pkg/storage/azure.go
@@ -8,7 +8,7 @@ import (
 	"github.com/Azure/azure-sdk-for-go/storage"
 )
 
-// AzureBlobBackend is a storage backend for Amazon S3
+// AzureBlobBackend is a storage backend for Azure Blob Storage
 type AzureBlobBackend struct {
 	Container  *storage.Container
 }
@@ -31,7 +31,7 @@ func NewAzureBlobBackend(accountName string, accountKey string, containerName st
 	return b
 }
 
-// ListObjects lists all objects in Amazon S3 bucket, at prefix
+// ListObjects lists all objects in Azure Blob Storage container
 func (b AzureBlobBackend) ListObjects() ([]Object, error) {
 	
 	var objects []Object
@@ -61,7 +61,7 @@ func (b AzureBlobBackend) ListObjects() ([]Object, error) {
 	return objects, nil
 }
 
-// GetObject retrieves an object from Amazon S3 bucket, at prefix
+// GetObject retrieves an object from Azure Blob Storage, at path
 func (b AzureBlobBackend) GetObject(path string) (Object, error) {
 	var object Object
 	object.Path = path
@@ -101,7 +101,7 @@ func (b AzureBlobBackend) GetObject(path string) (Object, error) {
 	return object, nil
 }
 
-// PutObject uploads an object to Amazon S3 bucket, at prefix
+// PutObject uploads an object to Azure Blob Storage container, at path
 func (b AzureBlobBackend) PutObject(path string, content []byte) error {
 	if (b.Container == nil) {
 		return errors.New("Unable to obtain a container reference.")
@@ -118,7 +118,7 @@ func (b AzureBlobBackend) PutObject(path string, content []byte) error {
 	return err
 }
 
-// DeleteObject removes an object from Amazon S3 bucket, at prefix
+// DeleteObject removes an object from Azure Blob Storage container, at path
 func (b AzureBlobBackend) DeleteObject(path string) error {
 	blobReference := b.Container.GetBlobReference(path)
 

--- a/pkg/storage/azure_test.go
+++ b/pkg/storage/azure_test.go
@@ -1,0 +1,63 @@
+package storage
+
+import (
+	"os"
+	"testing"
+
+	"github.com/stretchr/testify/suite"
+)
+
+type AzureTestSuite struct {
+	suite.Suite
+	BrokenAzureBlobBackend   *AzureBlobBackend
+	NoPrefixAzureBlobBackend *AzureBlobBackend
+}
+
+func (suite *AzureTestSuite) SetupSuite() {
+	backend := NewAzureBlobBackend("fake-account-cant-exist-fbce123", "", "charts")
+	suite.BrokenAzureBlobBackend = backend
+
+	accountName := os.Getenv("TEST_STORAGE_AZURE_NAME")
+	accountKey := os.Getenv("TEST_STORAGE_AZURE_KEY")
+	containerName := os.Getenv("TEST_STORAGE_AZURE_CONTAINER")
+
+	backend = NewAzureBlobBackend(accountName, accountKey, containerName)
+	suite.NoPrefixAzureBlobBackend = backend
+
+	data := []byte("some object")
+	path := "deleteme.txt"
+	err := suite.NoPrefixAzureBlobBackend.PutObject(path, data)
+	suite.Nil(err, "no error putting deleteme.txt using AmazonS3 backend")
+}
+
+func (suite *AzureTestSuite) TearDownSuite() {
+	err := suite.NoPrefixAzureBlobBackend.DeleteObject("deleteme.txt")
+	suite.Nil(err, "no error deleting deleteme.txt using AmazonS3 backend")
+}
+
+func (suite *AzureTestSuite) TestListObjects() {
+	_, err := suite.BrokenAzureBlobBackend.ListObjects()
+	suite.NotNil(err, "cannot list objects with bad bucket")
+
+	_, err = suite.NoPrefixAzureBlobBackend.ListObjects()
+	suite.Nil(err, "can list objects with good bucket, no prefix")
+}
+
+func (suite *AzureTestSuite) TestGetObject() {
+	_, err := suite.BrokenAzureBlobBackend.GetObject("this-file-cannot-possibly-exist.tgz")
+	suite.NotNil(err, "cannot get objects with bad bucket")
+}
+
+func (suite *AzureTestSuite) TestPutObject() {
+	err := suite.BrokenAzureBlobBackend.PutObject("this-file-will-not-upload.txt", []byte{})
+	suite.NotNil(err, "cannot put objects with bad bucket")
+}
+
+func TestAzureStorageTestSuite(t *testing.T) {
+	if os.Getenv("TEST_CLOUD_STORAGE") == "1" &&
+		os.Getenv("TEST_STORAGE_AZURE_NAME") != "" &&
+		os.Getenv("TEST_STORAGE_AZURE_KEY") != "" &&
+		os.Getenv("TEST_STORAGE_AZURE_CONTAINER") != "" {
+		suite.Run(t, new(AzureTestSuite))
+	}
+}

--- a/pkg/storage/azure_test.go
+++ b/pkg/storage/azure_test.go
@@ -27,12 +27,12 @@ func (suite *AzureTestSuite) SetupSuite() {
 	data := []byte("some object")
 	path := "deleteme.txt"
 	err := suite.NoPrefixAzureBlobBackend.PutObject(path, data)
-	suite.Nil(err, "no error putting deleteme.txt using AmazonS3 backend")
+	suite.Nil(err, "no error putting deleteme.txt using Azure backend")
 }
 
 func (suite *AzureTestSuite) TearDownSuite() {
 	err := suite.NoPrefixAzureBlobBackend.DeleteObject("deleteme.txt")
-	suite.Nil(err, "no error deleting deleteme.txt using AmazonS3 backend")
+	suite.Nil(err, "no error deleting deleteme.txt using Azure backend")
 }
 
 func (suite *AzureTestSuite) TestListObjects() {


### PR DESCRIPTION
Adds a backend implementation based on Azure Blob Storage. Its use and implementation is based on that for Amazon S3; I'm not a Go developer so I've tried to match it as closely as possible. By all means provide feedback on syntax, style, error handling, etc.

I wasn't able to get the acceptance tests running; any pointers related to their proper setup would be helpful.

Associated with #24.