### PR TITLE
Adds a health check endpoint, at the root address.

### DIFF
--- a/pkg/chartmuseum/handlers.go
+++ b/pkg/chartmuseum/handlers.go
@@ -29,6 +29,16 @@ type (
 	filenameFromContentFn func([]byte) (string, error)
 )
 
+func (server *Server) getHealthCheck(c *gin.Context) {
+	log := server.contextLoggingFn(c)
+	_, err := server.syncRepositoryIndex(log)
+	if err != nil {
+		c.JSON(500, errorResponse(err))
+		return
+	}
+	c.Data(200, "application/x-yaml", nil)
+}
+
 func (server *Server) getIndexFileRequestHandler(c *gin.Context) {
 	log := server.contextLoggingFn(c)
 	index, err := server.syncRepositoryIndex(log)

--- a/pkg/chartmuseum/handlers.go
+++ b/pkg/chartmuseum/handlers.go
@@ -18,6 +18,7 @@ var (
 	notFoundErrorResponse      = gin.H{"error": "not found"}
 	badExtensionErrorResponse  = gin.H{"error": "unsupported file extension"}
 	alreadyExistsErrorResponse = gin.H{"error": "file already exists"}
+	healthCheckResponse        = gin.H{"healthy": true}
 )
 
 type (
@@ -30,13 +31,7 @@ type (
 )
 
 func (server *Server) getHealthCheck(c *gin.Context) {
-	log := server.contextLoggingFn(c)
-	_, err := server.syncRepositoryIndex(log)
-	if err != nil {
-		c.JSON(500, errorResponse(err))
-		return
-	}
-	c.Data(200, "application/x-yaml", nil)
+	c.JSON(200, healthCheckResponse)
 }
 
 func (server *Server) getIndexFileRequestHandler(c *gin.Context) {

--- a/pkg/chartmuseum/routes.go
+++ b/pkg/chartmuseum/routes.go
@@ -1,17 +1,30 @@
 package chartmuseum
 
-func (server *Server) setRoutes(enableAPI bool) {
+import "github.com/gin-gonic/gin"
+
+func (server *Server) setRoutes(username string, password string, enableAPI bool) {
+	// Routes that never use basic HTTP Auth can be applied directly to the default Router
+	server.Router.GET("/", server.getHealthCheck)
+
+	// Routes that can use basic HTTP Auth must be applied to the basicAuthGroup Router Group
+	basicAuthGroup := server.Router.Group("")
+	if username != "" && password != "" {
+		users := make(map[string]string)
+		users[username] = password
+		basicAuthGroup.Use(gin.BasicAuthForRealm(users, "ChartMuseum"))
+	}
+
 	// Helm Chart Repository
-	server.Router.GET("/index.yaml", server.getIndexFileRequestHandler)
-	server.Router.GET("/charts/:filename", server.getStorageObjectRequestHandler)
+	basicAuthGroup.GET("/index.yaml", server.getIndexFileRequestHandler)
+	basicAuthGroup.GET("/charts/:filename", server.getStorageObjectRequestHandler)
 
 	// Chart Manipulation
 	if enableAPI {
-		server.Router.GET("/api/charts", server.getAllChartsRequestHandler)
-		server.Router.POST("/api/charts", server.postRequestHandler)
-		server.Router.POST("/api/prov", server.postProvenanceFileRequestHandler)
-		server.Router.GET("/api/charts/:name", server.getChartRequestHandler)
-		server.Router.GET("/api/charts/:name/:version", server.getChartVersionRequestHandler)
-		server.Router.DELETE("/api/charts/:name/:version", server.deleteChartVersionRequestHandler)
+		basicAuthGroup.GET("/api/charts", server.getAllChartsRequestHandler)
+		basicAuthGroup.POST("/api/charts", server.postRequestHandler)
+		basicAuthGroup.POST("/api/prov", server.postProvenanceFileRequestHandler)
+		basicAuthGroup.GET("/api/charts/:name", server.getChartRequestHandler)
+		basicAuthGroup.GET("/api/charts/:name/:version", server.getChartVersionRequestHandler)
+		basicAuthGroup.DELETE("/api/charts/:name/:version", server.deleteChartVersionRequestHandler)
 	}
 }

--- a/pkg/chartmuseum/routes.go
+++ b/pkg/chartmuseum/routes.go
@@ -6,7 +6,7 @@ import (
 
 func (server *Server) setRoutes(username string, password string, enableAPI bool) {
 	// Routes that never use basic HTTP Auth can be applied directly to the default Router
-	server.Router.GET("/", server.getHealthCheck)
+	server.Router.GET("/health", server.getHealthCheck)
 
 	// Routes that can use basic HTTP Auth must be applied to the basicAuthGroup Router Group
 	basicAuthGroup := server.Router.Group("")

--- a/pkg/chartmuseum/routes.go
+++ b/pkg/chartmuseum/routes.go
@@ -1,6 +1,8 @@
 package chartmuseum
 
-import "github.com/gin-gonic/gin"
+import (
+	"github.com/gin-gonic/gin"
+)
 
 func (server *Server) setRoutes(username string, password string, enableAPI bool) {
 	// Routes that never use basic HTTP Auth can be applied directly to the default Router

--- a/pkg/chartmuseum/server_test.go
+++ b/pkg/chartmuseum/server_test.go
@@ -240,9 +240,6 @@ func (suite *ServerTestSuite) TestRoutes() {
 	res = suite.doRequest("normal", "GET", "/", nil, "")
 	suite.Equal(200, res.Status(), "200 GET /")
 
-	res = suite.doRequest("broken", "GET", "/", nil, "")
-	suite.Equal(500, res.Status(), "500 GET /")
-
 	// GET /index.yaml
 	res = suite.doRequest("normal", "GET", "/index.yaml", nil, "")
 	suite.Equal(200, res.Status(), "200 GET /index.yaml")

--- a/pkg/chartmuseum/server_test.go
+++ b/pkg/chartmuseum/server_test.go
@@ -236,6 +236,13 @@ func (suite *ServerTestSuite) TestRoutes() {
 	res = suite.doRequest("normal", "DELETE", "/api/charts/mychart/0.1.0", nil, "")
 	suite.Equal(404, res.Status(), "404 DELETE /api/charts/mychart/0.1.0")
 
+	// GET /
+	res = suite.doRequest("normal", "GET", "/", nil, "")
+	suite.Equal(200, res.Status(), "200 GET /")
+
+	res = suite.doRequest("broken", "GET", "/", nil, "")
+	suite.Equal(500, res.Status(), "500 GET /")
+
 	// GET /index.yaml
 	res = suite.doRequest("normal", "GET", "/index.yaml", nil, "")
 	suite.Equal(200, res.Status(), "200 GET /index.yaml")

--- a/pkg/chartmuseum/server_test.go
+++ b/pkg/chartmuseum/server_test.go
@@ -237,8 +237,8 @@ func (suite *ServerTestSuite) TestRoutes() {
 	suite.Equal(404, res.Status(), "404 DELETE /api/charts/mychart/0.1.0")
 
 	// GET /
-	res = suite.doRequest("normal", "GET", "/", nil, "")
-	suite.Equal(200, res.Status(), "200 GET /")
+	res = suite.doRequest("normal", "GET", "/health", nil, "")
+	suite.Equal(200, res.Status(), "200 GET /health")
 
 	// GET /index.yaml
 	res = suite.doRequest("normal", "GET", "/index.yaml", nil, "")


### PR DESCRIPTION
Fixes #28 

Adds a health check endpoint at "/", which can be accessed without http auth, even when the server is initialized to use http auth.

The health check endpoint checks if `syncRepositoryIndex` is successful before returning a success code. I'm not sure if this is the best thing to check for the health check- I looked at the ChartMuseum chart in the Kubernetes Chart repo, and that is using "/index.yaml" for probes, which calls `syncRepositoryIndex`. I could change the health endpoint to check against something else though, if there is a better thing to check against for a healthy status.

