### PR TITLE
optionally allow anonymous read for GET operations when basic auth is…

### DIFF
--- a/README.md
+++ b/README.md
@@ -184,6 +184,10 @@ If both of the following options are provided, basic http authentication will pr
 - `--basic-auth-user=<user>` - username for basic http authentication
 - `--basic-auth-pass=<pass>` - password for basic http authentication
 
+You may want basic auth to only be applied to operations that can change Charts, i.e. PUT, POST and DELETE.  So to avoid basic auth on GET operations use
+
+- `--auth-anonymous-get=true` - allow anonymous GET operations
+
 #### HTTPS
 If both of the following options are provided, the server will listen and serve HTTPS:
 - `--tls-cert=<crt>` - path to tls certificate chain file

--- a/cmd/chartmuseum/main.go
+++ b/cmd/chartmuseum/main.go
@@ -53,6 +53,7 @@ func cliHandler(c *cli.Context) {
 		StorageBackend:         backend,
 		ChartPostFormFieldName: c.String("chart-post-form-field-name"),
 		ProvPostFormFieldName:  c.String("prov-post-form-field-name"),
+		AnonymousGet:           c.Bool("auth-anonymous-get"),
 	}
 
 	server, err := newServer(options)
@@ -242,5 +243,10 @@ var cliFlags = []cli.Flag{
 		Value:  "prov",
 		Usage:  "form field which will be queried for the provenance file content",
 		EnvVar: "PROV_POST_FORM_FIELD_NAME",
+	},
+	cli.BoolFlag{
+		Name:   "auth-anonymous-get",
+		Usage:  "allow anonymous GET operations when auth is used",
+		EnvVar: "AUTH_ANONYMOUS_GET",
 	},
 }

--- a/pkg/chartmuseum/server.go
+++ b/pkg/chartmuseum/server.go
@@ -27,6 +27,7 @@ type (
 		StorageBackend          storage.Backend
 		StorageCache            []storage.Object
 		AllowOverwrite          bool
+		AnonymousGet            bool
 		TlsCert                 string
 		TlsKey                  string
 		ChartPostFormFieldName  string
@@ -45,6 +46,7 @@ type (
 		EnableAPI              bool
 		AllowOverwrite         bool
 		EnableMetrics          bool
+		AnonymousGet           bool
 		ChartURL               string
 		TlsCert                string
 		TlsKey                 string
@@ -84,6 +86,7 @@ func NewServer(options ServerOptions) (*Server, error) {
 		StorageBackend:         options.StorageBackend,
 		StorageCache:           []storage.Object{},
 		AllowOverwrite:         options.AllowOverwrite,
+		AnonymousGet:           options.AnonymousGet,
 		TlsCert:                options.TlsCert,
 		TlsKey:                 options.TlsKey,
 		ChartPostFormFieldName: options.ChartPostFormFieldName,

--- a/pkg/chartmuseum/server_test.go
+++ b/pkg/chartmuseum/server_test.go
@@ -71,25 +71,25 @@ func (suite *ServerTestSuite) SetupSuite() {
 
 	backend := storage.Backend(storage.NewLocalFilesystemBackend(suite.TempDirectory))
 
-	server, err := NewServer(ServerOptions{backend, false, false, true, false, false, "", "", "", "", "", "", ""})
+	server, err := NewServer(ServerOptions{backend, false, false, true, false, false, false, "", "", "", "", "", "", ""})
 	suite.NotNil(server)
 	suite.Nil(err, "no error creating new server, logJson=false, debug=false, disabled=false, overwrite=false")
 
-	server, err = NewServer(ServerOptions{backend, true, true, true, false, false, "", "", "", "", "", "", ""})
+	server, err = NewServer(ServerOptions{backend, true, true, true, false, false, false, "", "", "", "", "", "", ""})
 	suite.NotNil(server)
 	suite.Nil(err, "no error creating new server, logJson=true, debug=true, disabled=false, overwrite=false")
 
-	server, err = NewServer(ServerOptions{backend, false, true, true, false, false, "", "", "", "user", "pass", "chart", "prov"})
+	server, err = NewServer(ServerOptions{backend, false, true, true, false, false, false, "", "", "", "user", "pass", "chart", "prov"})
 	suite.Nil(err, "no error creating new server, logJson=false, debug=true, disabled=false, overwrite=false")
 
 	suite.Server = server
 
-	disabledAPIServer, err := NewServer(ServerOptions{backend, false, true, false, false, false, "", "", "", "", "", "", ""})
+	disabledAPIServer, err := NewServer(ServerOptions{backend, false, true, false, false, false, false, "", "", "", "", "", "", ""})
 	suite.Nil(err, "no error creating new server, logJson=false, debug=true, disabled=true, overwrite=false")
 
 	suite.DisabledAPIServer = disabledAPIServer
 
-	overwriteServer, err := NewServer(ServerOptions{backend, false, true, true, true, false, "", "", "", "", "", "chart", "prov"})
+	overwriteServer, err := NewServer(ServerOptions{backend, false, true, true, true, false, false, "", "", "", "", "", "chart", "prov"})
 	suite.Nil(err, "no error creating new server, logJson=false, debug=true, disabled=false, overwrite=true")
 
 	suite.OverwriteServer = overwriteServer
@@ -120,7 +120,7 @@ func (suite *ServerTestSuite) SetupSuite() {
 	defer os.RemoveAll(suite.BrokenTempDirectory)
 
 	brokenBackend := storage.Backend(storage.NewLocalFilesystemBackend(suite.BrokenTempDirectory))
-	brokenServer, err := NewServer(ServerOptions{brokenBackend, false, true, true, false, false, "", "", "", "", "", "", ""})
+	brokenServer, err := NewServer(ServerOptions{brokenBackend, false, true, true, false, false, false, "", "", "", "", "", "", ""})
 	suite.Nil(err, "no error creating new server, logJson=false, debug=true, disabled=false, overwrite=false")
 
 	suite.BrokenServer = brokenServer


### PR DESCRIPTION
… enabled resolves kubernetes-helm/chartmuseum#34

This is just a suggestion but it seems to work nicely, not sure about the flag name `--auth-anonymous-get` though.