### PR TITLE
Upgrade to helm v2.8.0

### DIFF
--- a/glide.lock
+++ b/glide.lock
@@ -1,5 +1,5 @@
-hash: 6fe97c28fd00df1f86dbb6aa126a4136e1f536ef8828a8883b4a92f9050aea13
-updated: 2018-02-02T21:09:10.769871807-06:00
+hash: df87f8227be8fb5a87b1bc8eecae371256787e6c6fc664c36097708ea4275eca
+updated: 2018-02-06T11:14:32.105263156-08:00
 imports:
 - name: cloud.google.com/go
   version: 0f0b8420cb699ac4ce059c63bac263f4301fe95b
@@ -48,10 +48,6 @@ imports:
   - quantile
 - name: github.com/BurntSushi/toml
   version: b26d9c308763d68093482582cea63d69be07a0f0
-- name: github.com/facebookgo/atomicfile
-  version: 2de1f203e7d5e386a6833233882782932729f27e
-- name: github.com/facebookgo/symwalk
-  version: 42004b9f322246749dd73ad71008b1f3160c0052
 - name: github.com/ghodss/yaml
   version: 73d445a93680fa1a78ae23a5839bad48f32ba1ee
 - name: github.com/gin-contrib/sse
@@ -74,7 +70,7 @@ imports:
   - util/runes
   - util/strings
 - name: github.com/golang/protobuf
-  version: 2bba0603135d7d7f5cb73b2125beeda19c09f4ef
+  version: 4bd1920723d7b7c925de087aa32e2187708897f7
   subpackages:
   - proto
   - protoc-gen-go/descriptor
@@ -84,8 +80,6 @@ imports:
   version: 2cadd475a3e966ec9b77a21afc530dbacec6d613
 - name: github.com/jmespath/go-jmespath
   version: bd40a432e4c76585ef6b72d3fd96fb9b6dc7b68d
-- name: github.com/kubernetes/helm
-  version: 14af25f1de6832228539259b821949d20069a222
 - name: github.com/Masterminds/semver
   version: 517734cc7d6470c0d07130e40fd40bdeb9bcd3fd
 - name: github.com/mattn/go-isatty
@@ -114,13 +108,13 @@ imports:
   subpackages:
   - xfs
 - name: github.com/satori/go.uuid
-  version: 5bf94b69c6b68ee1b541973bb8e1144db23a194b
+  version: 879c5887cd475cd7864858769793b2ceb0d44feb
 - name: github.com/sirupsen/logrus
   version: 89742aefa4b206dcf400792f3bd35b542998eb3b
 - name: github.com/spf13/pflag
   version: 9ff6c6923cfffbcd502984b8e0c80539a94968b7
 - name: github.com/ugorji/go
-  version: 8c0409fcbb70099c748d71f714529204975f6c3f
+  version: ded73eae5db7e7a0ef6f55aace87a2873c5d2b74
   subpackages:
   - codec
 - name: github.com/urfave/cli
@@ -163,14 +157,14 @@ imports:
   - lex/httplex
   - trace
 - name: golang.org/x/oauth2
-  version: 9a379c6b3e95a790ffc43293c2a78dee0d7b6e20
+  version: a6bd8cefa1811bd24b86f8902872e4e8225f74c4
   subpackages:
   - google
   - internal
   - jws
   - jwt
 - name: golang.org/x/sys
-  version: 2d6f6f883a06fc0d5f4b14a81e4c28705ea64c15
+  version: 43eea11bc92608addb41b8a406b0407495c106f6
   subpackages:
   - unix
   - windows
@@ -194,7 +188,7 @@ imports:
   - storage/v1
   - transport/http
 - name: google.golang.org/appengine
-  version: d9a072cfa7b9736e44311ef77b3e09d804bfa599
+  version: 12d5545dc1cfa6047a286d5e853841b6471f4c19
   subpackages:
   - internal
   - internal/app_identity
@@ -206,7 +200,7 @@ imports:
   - internal/urlfetch
   - urlfetch
 - name: google.golang.org/genproto
-  version: ee236bd376b077c7a89f260c026c4735b195e459
+  version: 09f6ed296fc66555a25fe4ce95173148778dfa85
   subpackages:
   - googleapis/api/annotations
   - googleapis/iam/v1
@@ -231,13 +225,17 @@ imports:
 - name: gopkg.in/go-playground/validator.v8
   version: 5f1438d3fca68893a817e4a66806cea46a9e4ebf
 - name: gopkg.in/yaml.v2
-  version: eb3733d160e74a9c7e442f435eb3bea458e1d19f
+  version: 53feefa2559fb8dfa8d81baad31be332c97d6c77
 - name: k8s.io/apimachinery
-  version: dc1f89aff9a7509782bde3b68824c8043a3e58cc
+  version: 3b05bbfa0a45413bfa184edbf9af617e277962fb
   subpackages:
   - pkg/version
+- name: k8s.io/client-go
+  version: 82aa063804cf055e16e8911250f888bc216e8b61
+  subpackages:
+  - util/homedir
 - name: k8s.io/helm
-  version: 1dbbace83192680134c96861742cedda243fcd7e
+  version: 14af25f1de6832228539259b821949d20069a222
   subpackages:
   - pkg/chartutil
   - pkg/getter
@@ -249,8 +247,10 @@ imports:
   - pkg/proto/hapi/version
   - pkg/provenance
   - pkg/repo
+  - pkg/sympath
   - pkg/tlsutil
   - pkg/urlutil
+  - pkg/version
 testImports:
 - name: github.com/davecgh/go-spew
   version: 782f4967f2dc4564575ca782fe2d04090b5faca8

--- a/glide.yaml
+++ b/glide.yaml
@@ -3,7 +3,7 @@ package: github.com/kubernetes-helm/chartmuseum
 import:
 - package: github.com/gin-gonic/gin
   version: v1.2
-- package: github.com/kubernetes/helm
+- package: k8s.io/helm
   version: v2.8.0
 - package: github.com/urfave/cli
   version: v1.20.0


### PR DESCRIPTION
Upgrade helm v2.8.0 (including the packages from the k8s.io/helm path)