### PR TITLE
Make Dockerfile multistage

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,2 +1,2 @@
-*
-!bin/**
+bin/**
+vendor/

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,12 +1,14 @@
 # Build Binary
 FROM golang:1.8.3 as gobuild
+RUN apt-get update && \
+    apt-get -y install ca-certificates
 WORKDIR /go/src/github.com/kubernetes-helm/chartmuseum
 COPY . .
 RUN make bootstrap
 RUN make build_linux
 
 # Build Image
-FROM alpine:3.6
-RUN apk add --no-cache ca-certificates
+FROM scratch
+COPY --from=gobuild /etc/ssl/certs/ca-certificates.crt /etc/ssl/certs/
 COPY --from=gobuild /go/src/github.com/kubernetes-helm/chartmuseum/bin/linux/amd64/chartmuseum /chartmuseum
 ENTRYPOINT ["/chartmuseum"]

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,12 @@
+# Build Binary
+FROM golang:1.8.3 as gobuild
+WORKDIR /go/src/github.com/kubernetes-helm/chartmuseum
+COPY . .
+RUN make bootstrap
+RUN make build_linux
+
+# Build Image
 FROM alpine:3.6
 RUN apk add --no-cache ca-certificates
-COPY bin/linux/amd64/chartmuseum /chartmuseum
+COPY --from=gobuild /go/src/github.com/kubernetes-helm/chartmuseum/bin/linux/amd64/chartmuseum /chartmuseum
 ENTRYPOINT ["/chartmuseum"]


### PR DESCRIPTION
Use docker build multistage functionality to have self-contained docker builds. This makes docker the only dependency required for the build.

Open for suggestions as to which Go version to build from, I just happened to use 1.8.3 as it's the version we use internally.