### PR TITLE
return 409 for chart already exists

### DIFF
--- a/pkg/chartmuseum/handlers.go
+++ b/pkg/chartmuseum/handlers.go
@@ -226,7 +226,7 @@ func (server *Server) postPackageRequestHandler(c *gin.Context) {
 	if !server.AllowOverwrite {
 		_, err = server.StorageBackend.GetObject(filename)
 		if err == nil {
-			c.JSON(500, alreadyExistsErrorResponse)
+			c.JSON(409, alreadyExistsErrorResponse)
 			return
 		}
 	}
@@ -255,7 +255,7 @@ func (server *Server) postProvenanceFileRequestHandler(c *gin.Context) {
 	if !server.AllowOverwrite {
 		_, err = server.StorageBackend.GetObject(filename)
 		if err == nil {
-			c.JSON(500, alreadyExistsErrorResponse)
+			c.JSON(409, alreadyExistsErrorResponse)
 			return
 		}
 	}

--- a/pkg/chartmuseum/server_test.go
+++ b/pkg/chartmuseum/server_test.go
@@ -269,7 +269,7 @@ func (suite *ServerTestSuite) TestRoutes() {
 
 	body = bytes.NewBuffer(content)
 	res = suite.doRequest("basicauth", "POST", "/api/charts", body, "")
-	suite.Equal(500, res.Status(), "500 POST /api/charts")
+	suite.Equal(409, res.Status(), "500 POST /api/charts")
 
 	// POST /api/prov
 	content, err = ioutil.ReadFile(testProvfilePath)
@@ -281,7 +281,7 @@ func (suite *ServerTestSuite) TestRoutes() {
 
 	body = bytes.NewBuffer(content)
 	res = suite.doRequest("basicauth", "POST", "/api/prov", body, "")
-	suite.Equal(500, res.Status(), "500 POST /api/prov")
+	suite.Equal(409, res.Status(), "500 POST /api/prov")
 
 	// Test that all /api routes disabled if EnableAPI=false
 	res = suite.doRequest("disabled", "GET", "/api/charts", nil, "")


### PR DESCRIPTION
Fixes #42

cc @davidovich 

I want to deprecate the --data-binary option, but it should be done at a later point, such as when making breaking API changes.