### PR TITLE
Add HTML welcome page at root route

### DIFF
--- a/README.md
+++ b/README.md
@@ -53,6 +53,7 @@ Powered by some great Go technology:
 - `GET /api/charts/<name>/<version>` - describe a chart version
 
 ### Server Info
+- `GET /` - HTML welcome page
 - `GET /health` - returns 200 OK
 
 ## Uploading a Chart Package

--- a/glide.lock
+++ b/glide.lock
@@ -1,5 +1,5 @@
-hash: 18422b04371f3b35164e2b4ee878c7047a328b37fc89e4a02839f8d659e54aa2
-updated: 2018-02-14T15:21:39.920654822-06:00
+hash: dd0a48300d5bed94d76cfa166b2550aaf3da17f1cd8646c4bb1028aeabe2cf8d
+updated: 2018-02-19T17:22:05.874526-06:00
 imports:
 - name: cloud.google.com/go
   version: 3137f1def9552929c7beb11f2ac7d2dd998e4040
@@ -66,6 +66,8 @@ imports:
   version: dbeaa9332f19a944acb5736b4456cfcc02140e29
 - name: github.com/ghodss/yaml
   version: 73d445a93680fa1a78ae23a5839bad48f32ba1ee
+- name: github.com/gin-contrib/location
+  version: 5220ebf8be6c350431168cbd884f2c0ace0e3f4c
 - name: github.com/gin-contrib/sse
   version: 22d885f9ecc78bf4ee5d72b937e4bbcdc58e8cae
 - name: github.com/gin-gonic/gin

--- a/glide.yaml
+++ b/glide.yaml
@@ -15,6 +15,8 @@ import:
   version: e26effb6cde37935f313bb3d5e5a1207f44cff69
 - package: github.com/atarantini/ginrequestid
   version: a432ade0ce478903613da1372cb5a62914cfe532
+- package: github.com/gin-contrib/location
+  version: 5220ebf8be6c350431168cbd884f2c0ace0e3f4c
 
 # Used by Microsoft Azure Blob storage backend
 - package: github.com/Azure/azure-sdk-for-go

--- a/pkg/chartmuseum/handlers.go
+++ b/pkg/chartmuseum/handlers.go
@@ -20,20 +20,7 @@ var (
 	badExtensionErrorResponse  = gin.H{"error": "unsupported file extension"}
 	alreadyExistsErrorResponse = gin.H{"error": "file already exists"}
 	healthCheckResponse        = gin.H{"healthy": true}
-)
-
-type (
-	packageOrProvenanceFile struct {
-		filename string
-		content  []byte
-		field    string // file was extracted from this form field
-	}
-	filenameFromContentFn func([]byte) (string, error)
-)
-
-func (server *Server) getWelcomePageHandler(c *gin.Context) {
-	c.Data(200, "text/html", []byte(fmt.Sprintf(
-		`<!DOCTYPE html>
+	welcomePageHTMLTemplate    = `<!DOCTYPE html>
 <html>
 <head>
 <title>Welcome to ChartMuseum!</title>
@@ -59,7 +46,21 @@ working.</p>
 <p><em>Thank you for using ChartMuseum.</em></p>
 </body>
 </html>
-	`, location.Get(c))))
+	`
+)
+
+type (
+	packageOrProvenanceFile struct {
+		filename string
+		content  []byte
+		field    string // file was extracted from this form field
+	}
+	filenameFromContentFn func([]byte) (string, error)
+)
+
+func (server *Server) getWelcomePageHandler(c *gin.Context) {
+	url := location.Get(c)
+	c.Data(200, "text/html", []byte(fmt.Sprintf(welcomePageHTMLTemplate, url)))
 }
 
 func (server *Server) getHealthCheckHandler(c *gin.Context) {

--- a/pkg/chartmuseum/handlers.go
+++ b/pkg/chartmuseum/handlers.go
@@ -9,6 +9,7 @@ import (
 
 	"github.com/kubernetes-helm/chartmuseum/pkg/repo"
 
+	"github.com/gin-contrib/location"
 	"github.com/gin-gonic/gin"
 )
 
@@ -30,7 +31,38 @@ type (
 	filenameFromContentFn func([]byte) (string, error)
 )
 
-func (server *Server) getHealthCheck(c *gin.Context) {
+func (server *Server) getWelcomePageHandler(c *gin.Context) {
+	c.Data(200, "text/html", []byte(fmt.Sprintf(
+		`<!DOCTYPE html>
+<html>
+<head>
+<title>Welcome to ChartMuseum!</title>
+<style>
+    body {
+        width: 35em;
+        margin: 0 auto;
+        font-family: Tahoma, Verdana, Arial, sans-serif;
+    }
+</style>
+</head>
+<body>
+<h1>Welcome to ChartMuseum!</h1>
+<p>If you see this page, the ChartMuseum web server is successfully installed and
+working.</p>
+
+<p>To add this as a local chart repository, please run the following command:</p>
+<pre>helm repo add chartmuseum %s</pre>
+
+<p>For online documentation and support please refer to the
+<a href="https://github.com/kubernetes-helm/chartmuseum">GitHub project</a>.<br/>
+
+<p><em>Thank you for using ChartMuseum.</em></p>
+</body>
+</html>
+	`, location.Get(c))))
+}
+
+func (server *Server) getHealthCheckHandler(c *gin.Context) {
 	c.JSON(200, healthCheckResponse)
 }
 

--- a/pkg/chartmuseum/routes.go
+++ b/pkg/chartmuseum/routes.go
@@ -24,7 +24,8 @@ func (server *Server) setRoutes(username string, password string, enableAPI bool
 	}
 
 	// Server Info
-	sysInfoGroup.GET("/health", server.getHealthCheck)
+	sysInfoGroup.GET("/", server.getWelcomePageHandler)
+	sysInfoGroup.GET("/health", server.getHealthCheckHandler)
 
 	// Helm Chart Repository
 	readAccessGroup.GET("/index.yaml", server.getIndexFileRequestHandler)

--- a/pkg/chartmuseum/server.go
+++ b/pkg/chartmuseum/server.go
@@ -9,6 +9,7 @@ import (
 	"github.com/kubernetes-helm/chartmuseum/pkg/storage"
 
 	"github.com/atarantini/ginrequestid"
+	"github.com/gin-contrib/location"
 	"github.com/gin-gonic/gin"
 	"github.com/zsais/go-gin-prometheus"
 )
@@ -61,7 +62,7 @@ type (
 func NewRouter(logger *Logger, enableMetrics bool) *Router {
 	gin.SetMode(gin.ReleaseMode)
 	engine := gin.New()
-	engine.Use(ginrequestid.RequestId(), loggingMiddleware(logger), gin.Recovery())
+	engine.Use(location.Default(), ginrequestid.RequestId(), loggingMiddleware(logger), gin.Recovery())
 	if enableMetrics {
 		p := ginprometheus.NewPrometheus("chartmuseum")
 		p.ReqCntURLLabelMappingFn = mapURLWithParamsBackToRouteTemplate

--- a/pkg/chartmuseum/server_test.go
+++ b/pkg/chartmuseum/server_test.go
@@ -238,7 +238,12 @@ func (suite *ServerTestSuite) TestRoutes() {
 	res = suite.doRequest("basicauth", "DELETE", "/api/charts/mychart/0.1.0", nil, "")
 	suite.Equal(404, res.Status(), "404 DELETE /api/charts/mychart/0.1.0")
 
-	// GET /
+	// GET / (welcome page)
+	res = suite.doRequest("anonymous", "GET", "/", nil, "")
+	suite.Equal(200, res.Status(), "200 GET /")
+	suite.Equal("text/html", res.Header().Get("Content-Type"), "welcome page is html")
+
+	// GET /health
 	res = suite.doRequest("anonymous", "GET", "/health", nil, "")
 	suite.Equal(200, res.Status(), "200 GET /health")
 


### PR DESCRIPTION
Added an HTML welcome page at "/", based on the nginx one.

It also shows an example command of how to add the repo, using the gin-contrib/location package to determine the base URL: https://github.com/gin-contrib/location

cc: @liamawhite @davidovich 