### PR TITLE
Multi-Tenancy POC

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -15,6 +15,8 @@
 .test/
 .venv/
 bin/
+gorm.db
+gorm.db-journal
 goviz.png
 index.yaml
 mirror/

--- a/Makefile
+++ b/Makefile
@@ -28,13 +28,13 @@ build_windows:
 	    -o bin/windows/amd64/chartmuseum cmd/chartmuseum/main.go  # windows
 
 build_linux: export GOARCH=amd64
-build_linux: export CGO_ENABLED=0
+build_linux: export CGO_ENABLED=1
 build_linux:
 	@GOOS=linux go build -v --ldflags="-w -X main.Version=$(VERSION) -X main.Revision=$(REVISION)" \
 	    -o bin/linux/amd64/chartmuseum cmd/chartmuseum/main.go  # linux
 
 build_mac: export GOARCH=amd64
-build_mac: export CGO_ENABLED=0
+build_mac: export CGO_ENABLED=1
 build_mac:
 	@GOOS=darwin go build -v --ldflags="-w -X main.Version=$(VERSION) -X main.Revision=$(REVISION)" \
 	    -o bin/darwin/amd64/chartmuseum cmd/chartmuseum/main.go # mac osx

--- a/glide.lock
+++ b/glide.lock
@@ -1,5 +1,5 @@
-hash: dd0a48300d5bed94d76cfa166b2550aaf3da17f1cd8646c4bb1028aeabe2cf8d
-updated: 2018-02-19T17:22:05.874526-06:00
+hash: f4826202c9871b42228762658f7e0b61c79ca535022ddc1772b69d826b657b63
+updated: 2018-02-27T09:51:05.637384-06:00
 imports:
 - name: cloud.google.com/go
   version: 3137f1def9552929c7beb11f2ac7d2dd998e4040
@@ -98,6 +98,12 @@ imports:
   - ptypes/timestamp
 - name: github.com/googleapis/gax-go
   version: 2cadd475a3e966ec9b77a21afc530dbacec6d613
+- name: github.com/jinzhu/gorm
+  version: 48a20a6e9f3f4d26095df82c3337efec6db0a6fc
+  subpackages:
+  - dialects/sqlite
+- name: github.com/jinzhu/inflection
+  version: 1c35d901db3da928c72a72d8458480cc9ade058f
 - name: github.com/jmespath/go-jmespath
   version: bd40a432e4c76585ef6b72d3fd96fb9b6dc7b68d
 - name: github.com/marstr/guid
@@ -106,6 +112,8 @@ imports:
   version: 517734cc7d6470c0d07130e40fd40bdeb9bcd3fd
 - name: github.com/mattn/go-isatty
   version: fc9e8d8ef48496124e79ae0df75490096eccf6fe
+- name: github.com/mattn/go-sqlite3
+  version: 696e2e43cb00dcb1acaf6073e01493e3c4197b75
 - name: github.com/matttproud/golang_protobuf_extensions
   version: fc2b8d3a73c4867e51861bbdd5ae3c1f0869dd6a
   subpackages:

--- a/glide.yaml
+++ b/glide.yaml
@@ -31,6 +31,10 @@ import:
 - package: golang.org/x/oauth2
   version: 9a379c6b3e95a790ffc43293c2a78dee0d7b6e20
 
+# Database-related
+- package: github.com/jinzhu/gorm
+  version: v1.9
+
 testImports:
 - package: github.com/stretchr/testify
   version: v1.1.4

--- a/pkg/chartmuseum/database.go
+++ b/pkg/chartmuseum/database.go
@@ -1,0 +1,66 @@
+package chartmuseum
+
+import (
+	"github.com/gin-gonic/gin"
+	"github.com/jinzhu/gorm"
+	_ "github.com/jinzhu/gorm/dialects/sqlite"
+)
+
+type (
+	// Database stores application data
+	Database struct {
+		*gorm.DB
+	}
+
+	// Org is a database model that represents an organization
+	Org struct {
+		gorm.Model
+		Name  string `gorm:"unique_index"`
+		Repos []Repo `gorm:"foreignkey:OrgID"`
+	}
+
+	// Repo is a database model that represents a repo
+	Repo struct {
+		gorm.Model
+		Name  string `gorm:"unique_index"`
+		OrgID uint
+		Org   *Org `json:"-"`
+	}
+)
+
+// NewDatabase creates a new Database instance
+func NewDatabase() (*Database, error) {
+	database, err := gorm.Open("sqlite3", "./gorm.db")
+	if err != nil {
+		return new(Database), err
+	}
+	database.AutoMigrate(&Org{}, &Repo{})
+	return &Database{database}, nil
+}
+
+// adds org and repo to context (if present in URL params)
+func databaseMiddleware(database *Database) gin.HandlerFunc {
+	return func(c *gin.Context) {
+		if orgName := c.Param("org"); orgName != "" {
+			var org Org
+			if err := database.Preload("Repos").Where("name = ?", orgName).First(&org).Error; err == nil {
+				c.Set("org", &org)
+				if repoName := c.Param("repo"); repoName != "" {
+					var repo Repo
+					if err = database.Where("name = ? AND org_id = ?", repoName, org.ID).First(&repo).Error; err == nil {
+						c.Set("repo", &repo)
+					} else {
+						c.JSON(404, gin.H{"error": "repo not found"})
+						c.Abort()
+						return
+					}
+				}
+			} else {
+				c.JSON(404, gin.H{"error": "org not found"})
+				c.Abort()
+				return
+			}
+		}
+		c.Next()
+	}
+}

--- a/pkg/chartmuseum/routes.go
+++ b/pkg/chartmuseum/routes.go
@@ -23,6 +23,36 @@ func (server *Server) setRoutes(username string, password string, enableAPI bool
 		}
 	}
 
+	// Multi-Tenancy POC
+	orgAccessGroup := server.Router.Group("/mt")
+	orgAccessGroup.Use(databaseMiddleware(server.Database))
+	{
+		// Fetch index.yaml, .tgz, .prov files from storage
+		orgAccessGroup.GET("/:org/:repo/index.yaml", server.getOrgRepoIndexFileRequestHandler)
+		orgAccessGroup.GET("/:org/:repo/charts/:filename", server.getOrgRepoStorageObjectRequestHandler)
+
+		if enableAPI {
+			// Org operations
+			orgAccessGroup.GET("/", server.getOrgsRequestHandler)
+			orgAccessGroup.POST("/", server.createOrgRequestHandler)
+			orgAccessGroup.GET("/:org", server.getOrgRequestHandler)
+			orgAccessGroup.DELETE("/:org", server.deleteOrgRequestHandler)
+
+			// Org-owned Repo operations
+			orgAccessGroup.POST("/:org", server.createRepoRequestHandler)
+			orgAccessGroup.GET("/:org/:repo", server.getRepoRequestHandler)
+			orgAccessGroup.DELETE("/:org/:repo", server.deleteRepoRequestHandler)
+
+			// TODO: ChartMuseum CRUD API per Org-Repo combination
+			//orgAccessGroup.GET("/:org/:repo/api/charts", server.getAllChartsRequestHandler)
+			//orgAccessGroup.GET("/:org/:repo/api/charts/:name", server.getChartRequestHandler)
+			//orgAccessGroup.GET("/:org/:repo/api/charts/:name/:version", server.getChartVersionRequestHandler)
+			//orgAccessGroup.POST("/:org/:repo/api/charts", server.postRequestHandler)
+			//orgAccessGroup.POST("/:org/:repo/api/prov", server.postProvenanceFileRequestHandler)
+			//orgAccessGroup.DELETE("/:org/:repo/api/charts/:name/:version", server.deleteChartVersionRequestHandler)
+		}
+	}
+
 	// Server Info
 	sysInfoGroup.GET("/", server.getWelcomePageHandler)
 	sysInfoGroup.GET("/health", server.getHealthCheckHandler)


### PR DESCRIPTION
POC for enabling multi-tenancy. Do not merge. This is just meant to begin an open dialogue.

This introduces the popular [GORM](https://github.com/jinzhu/gorm) package to connect to temporary sqlite3 database "./gorm.db". GORM has support for mssql, mysql, and postgres as well.

GORM is an object relational mapper (ORM) library with syntax similar to Perl's DBIx::Class, which adds user-friendly methods and minimizes amount of raw SQL in the code.

Two database models have been created: Org and Repo. An Org has one-to-many Repos. A Repo is a ChartMuseum repo as we know it today.

Routes for working in/manipulating Orgs and Repos have been added under the temporary "/mt" prefix:
- `GET /mt/:org/:repo/index.yaml` - get index.yaml
- `GET /mt/:org/:repo/charts/:filename` - get chart packages etc.
- `GET /mt` - get all orgs
- `POST /mt` - create org
- `GET /mt/:org` - get org
- `DELETE /mt/:org` - delete org
- `POST /mt/:org` - create repo
- `GET /mt/:org/:repo` - get repo
- `DELETE /mt/:org/:repo` - delete repo

The routes above are all wrapped in `databaseMiddleware`, which add the the Org and Repo objects to the Gin context. If either are not found, we return a 404 and abort the request.

Things NOT covered in this POC:
- Custom database configuration
- Custom storage configuration per repo (should we even do this?)
- Caching of index.yaml per each repo. Currently hardcoded to look at `./charts/myorg/myrepo` dir on local filesystem, and generated upon every request
- ChartMuseum CRUD API per repo (e.g. `curl http://localhost:8080/mt/:org/:repo/api/charts`)

Open questions:
- How do we appropriately cache the index.yaml/chart metadata per repo? Need Redis?
- To prevent large number of `ListObjects` operations, should references to chart packages be stored in relational db as well? Do we rely on the db records instead of what's actually in storage?
- How can we enable RBAC on this? Can we start with just adding a `--disable-org-api` flag? How do we suggest people can plug this into their own internal auth system?
- Helm repos only support basic auth at this time. Should the auth mechanism for manipulating orgs, repos, charts, etc. differ from that of the helm repos themselves?
- Should ChartMuseum users still be able to use the original, database-less web server? Should multi-tenancy be enabled by default? Many users are satisfied with the current set of functionality

cc: @SlickNik @liamawhite @davidovich @mattfarina @itaysk @verchol @olegs-codefresh 