### PR TITLE
Fix azure storage example

### DIFF
--- a/README.md
+++ b/README.md
@@ -182,7 +182,7 @@ To do so, you must set the following env vars:
 
 ```bash
 chartmuseum --debug --port=8080 \
-  --storage="azure" \
+  --storage="microsoft" \
   --storage-microsoft-container="mycontainer" \
   --storage-microsoft-prefix=""
 ```


### PR DESCRIPTION
Seems like this commit https://github.com/kubernetes-helm/chartmuseum/commit/57542af46f66c7f861b0a8a3353a8ce9bad7b9b0  didn't catch all the references