### PR TITLE
Added --index-limit argument to limit parallel index scanning

### DIFF
--- a/README.md
+++ b/README.md
@@ -239,6 +239,7 @@ The contents of index.yaml will be printed to stdout and the program will exit. 
 - `--storage-amazon-sse=<algorithm>` - s3 server side encryption algorithm
 - `--chart-post-form-field-name=<field>` - form field which will be queried for the chart file content
 - `--prov-post-form-field-name=<field>` - form field which will be queried for the provenance file content
+- `--index-limit=<number>` - limit the number of parallel indexers to <number>
 
 ### Docker Image
 Available via [Docker Hub](https://hub.docker.com/r/chartmuseum/chartmuseum/).

--- a/README.md
+++ b/README.md
@@ -293,3 +293,4 @@ chartmuseum --debug --port=8080 --storage="local" --storage-local-rootdir="./mir
 
 ## Community
 You can reach the *ChartMuseum* community and developers in the [Kubernetes Slack](https://slack.k8s.io) **#chartmuseum** channel.
+

--- a/cmd/chartmuseum/main.go
+++ b/cmd/chartmuseum/main.go
@@ -310,7 +310,7 @@ var cliFlags = []cli.Flag{
 	},
 	cli.IntFlag{
 		Name:   "index-limit",
-		Value:  250,
+		Value:  0,
 		Usage:  "parallel scan limit for the repo indexer",
 		EnvVar: "INDEX_LIMIT",
 	},

--- a/cmd/chartmuseum/main.go
+++ b/cmd/chartmuseum/main.go
@@ -54,6 +54,7 @@ func cliHandler(c *cli.Context) {
 		ChartPostFormFieldName: c.String("chart-post-form-field-name"),
 		ProvPostFormFieldName:  c.String("prov-post-form-field-name"),
 		AnonymousGet:           c.Bool("auth-anonymous-get"),
+		IndexLimit:             c.Int("index-limit"),
 	}
 
 	server, err := newServer(options)
@@ -306,5 +307,11 @@ var cliFlags = []cli.Flag{
 		Value:  "prov",
 		Usage:  "form field which will be queried for the provenance file content",
 		EnvVar: "PROV_POST_FORM_FIELD_NAME",
+	},
+	cli.IntFlag{
+		Name:   "index-limit",
+		Value:  250,
+		Usage:  "parallel scan limit for the repo indexer",
+		EnvVar: "INDEX_LIMIT",
 	},
 }

--- a/pkg/chartmuseum/cache.go
+++ b/pkg/chartmuseum/cache.go
@@ -217,9 +217,13 @@ func (server *Server) addIndexObjectsAsync(log loggingFn, index *repo.Index, obj
 	// Limit parallelism to the index-limit parameter value
 	limiter := make(chan bool, server.IndexLimit)
 	for _, object := range objects {
-		limiter <- true
+		if server.IndexLimit != 0 {
+			limiter <- true
+		}
 		go func(o storage.Object) {
-			<-limiter
+			if server.IndexLimit != 0 {
+				<-limiter
+			}
 			select {
 			case <-ctx.Done():
 				return
@@ -236,9 +240,11 @@ func (server *Server) addIndexObjectsAsync(log loggingFn, index *repo.Index, obj
 		}(object)
 	}
 	// Wait for remaining func() calls to terminate
-        for i := 0; i < cap(limiter); i++ {
-            limiter <- true
-        }
+	if server.IndexLimit != 0 {
+		for i := 0; i < cap(limiter); i++ {
+			limiter <- true
+		}
+	}
 
 	for validCount := 0; validCount < numObjects; validCount++ {
 		cvRes := <-cvChan

--- a/pkg/chartmuseum/server.go
+++ b/pkg/chartmuseum/server.go
@@ -37,6 +37,7 @@ type (
 		fetchedObjectsLock      *sync.Mutex
 		fetchedObjectsChans     []chan fetchedObjects
 		regeneratedIndexesChans []chan indexRegeneration
+		IndexLimit		int
 	}
 
 	// ServerOptions are options for constructing a Server
@@ -55,6 +56,7 @@ type (
 		Password               string
 		ChartPostFormFieldName string
 		ProvPostFormFieldName  string
+		IndexLimit		int
 	}
 )
 
@@ -94,6 +96,7 @@ func NewServer(options ServerOptions) (*Server, error) {
 		ProvPostFormFieldName:  options.ProvPostFormFieldName,
 		regenerationLock:       &sync.Mutex{},
 		fetchedObjectsLock:     &sync.Mutex{},
+		IndexLimit:		options.IndexLimit,
 	}
 
 	server.setRoutes(options.Username, options.Password, options.EnableAPI)


### PR DESCRIPTION
This addresses https://github.com/kubernetes-helm/chartmuseum/issues/58 by adding a limiter to the parallel scanning of the storage location.

