### PR TITLE
Initial version of multitenant server

### DIFF
--- a/README.md
+++ b/README.md
@@ -274,9 +274,7 @@ If interested in making changes, please submit a PR to kubernetes/charts. Before
 ## Multitenancy
 Multitenant support is currently under active development and is considered **experimental**.
 
-Important things to note:
-- local filesystem storage is the only tested backend
-- all "Chart Manipulation" routes are disabled
+Please note that all "Chart Manipulation" routes are currently disabled.
 
 To begin, start with a directory structure such as
 ```
@@ -297,6 +295,8 @@ chartmuseum --debug --port=8080 --multitenant --storage="local" --storage-local-
 This example will provide two separate Helm Chart Repositories at the following locations:
 - `http://localhost:8080/r/org1/repoa`
 - `http://localhost:8080/r/org2/repob`
+
+This should work with all supported storage backends.
 
 ## Notes on index.yaml
 The repository index (index.yaml) is dynamically generated based on packages found in storage. If you store your own version of index.yaml, it will be completely ignored.

--- a/README.md
+++ b/README.md
@@ -293,8 +293,8 @@ chartmuseum --debug --port=8080 --multitenant --storage="local" --storage-local-
 ```
 
 This example will provide two separate Helm Chart Repositories at the following locations:
-- `http://localhost:8080/r/org1/repoa`
-- `http://localhost:8080/r/org2/repob`
+- `http://localhost:8080/org1/repoa`
+- `http://localhost:8080/org2/repob`
 
 This should work with all supported storage backends.
 

--- a/README.md
+++ b/README.md
@@ -271,6 +271,33 @@ helm install incubator/chartmuseum
 
 If interested in making changes, please submit a PR to kubernetes/charts. Before doing any work, please check for any [currently open pull requests](https://github.com/kubernetes/charts/pulls?q=is%3Apr+is%3Aopen+chartmuseum). Thanks!
 
+## Multitenancy
+Multitenant support is currently under active development and is considered **experimental**.
+
+Important things to note:
+- local filesystem storage is the only tested backend
+- all "Chart Manipulation" routes are disabled
+
+To begin, start with a directory structure such as
+```
+charts
+├── org1
+│   ├── repoa
+│   │   └── nginx-ingress-0.9.3.tgz
+├── org2
+│   ├── repob
+│   │   └── chartmuseum-0.4.0.tgz
+```
+
+Start the server with the `--multitenant` option, pointing to the `charts/` directory:
+```
+chartmuseum --debug --port=8080 --multitenant --storage="local" --storage-local-rootdir=./charts 
+```
+
+This example will provide two separate Helm Chart Repositories at the following locations:
+- `http://localhost:8080/r/org1/repoa`
+- `http://localhost:8080/r/org2/repob`
+
 ## Notes on index.yaml
 The repository index (index.yaml) is dynamically generated based on packages found in storage. If you store your own version of index.yaml, it will be completely ignored.
 

--- a/cmd/chartmuseum/main.go
+++ b/cmd/chartmuseum/main.go
@@ -6,6 +6,7 @@ import (
 	"os"
 	"strings"
 
+	"github.com/kubernetes-helm/chartmuseum/pkg/cache"
 	"github.com/kubernetes-helm/chartmuseum/pkg/chartmuseum"
 	"github.com/kubernetes-helm/chartmuseum/pkg/storage"
 
@@ -36,9 +37,11 @@ func main() {
 
 func cliHandler(c *cli.Context) {
 	backend := backendFromContext(c)
+	cacheStore := cacheStoreFromContext(c)
 
 	options := chartmuseum.ServerOptions{
 		StorageBackend:         backend,
+		Cache:                  cacheStore,
 		ChartURL:               c.String("chart-url"),
 		TlsCert:                c.String("tls-cert"),
 		TlsKey:                 c.String("tls-key"),
@@ -136,6 +139,12 @@ func alibabaBackendFromContext(c *cli.Context) storage.Backend {
 		c.String("storage-alibaba-endpoint"),
 		c.String("storage-alibaba-sse"),
 	))
+}
+
+func cacheStoreFromContext(c *cli.Context) cache.Store {
+	// TODO inspect c for Redis args, return Redis store
+	store := cache.NewInMemoryStore()
+	return store
 }
 
 func crashIfContextMissingFlags(c *cli.Context, flags []string) {

--- a/pkg/cache/inmemory.go
+++ b/pkg/cache/inmemory.go
@@ -1,0 +1,66 @@
+package cache
+
+import (
+	"errors"
+	"fmt"
+	"sync"
+)
+
+type (
+	// InMemoryStore implements the Store interface, used for storing objects in-memory
+	InMemoryStore struct {
+		Keys    map[string]*InMemoryObject
+		KeyLock *sync.Mutex
+	}
+
+	// InMemoryObject represents a single in-memory key value
+	InMemoryObject struct {
+		Contents  interface{}
+		WriteLock *sync.Mutex
+	}
+)
+
+// NewInMemoryObject creates a new, empty InMemoryStore
+func NewInMemoryStore() *InMemoryStore {
+	store := &InMemoryStore{
+		Keys:    map[string]*InMemoryObject{},
+		KeyLock: &sync.Mutex{},
+	}
+	return store
+}
+
+// Get returns an object at key
+func (store *InMemoryStore) Get(key string) (interface{}, error) {
+	if object, ok := store.Keys[key]; ok {
+		return object.Contents, nil
+	}
+	return nil, errors.New(fmt.Sprintf("Could not find key \"%s\"", key))
+}
+
+// Set saves a new value for key
+func (store *InMemoryStore) Set(key string, contents interface{}) error {
+	if object, ok := store.Keys[key]; ok {
+		object.WriteLock.Lock()
+		object.Contents = contents
+		object.WriteLock.Unlock()
+	} else {
+		store.KeyLock.Lock()
+		store.Keys[key] = &InMemoryObject{
+			Contents:  contents,
+			WriteLock: &sync.Mutex{},
+		}
+		store.KeyLock.Unlock()
+	}
+	return nil
+}
+
+// Delete removes a key from the store
+func (store *InMemoryStore) Delete(key string) error {
+	if _, ok := store.Keys[key]; ok {
+		store.KeyLock.Lock()
+		delete(store.Keys, key)
+		store.KeyLock.Unlock()
+		return nil
+	}
+	return errors.New(fmt.Sprintf("Could not find key \"%s\"", key))
+}

--- a/pkg/cache/store.go
+++ b/pkg/cache/store.go
@@ -1,0 +1,10 @@
+package cache
+
+type (
+	// Store is a generic interface for cache stores
+	Store interface {
+		Get(key string) (interface{}, error)
+		Set(key string, contents interface{}) error
+		Delete(key string) error
+	}
+)

--- a/pkg/cache/store_test.go
+++ b/pkg/cache/store_test.go
@@ -1,0 +1,51 @@
+package cache
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/stretchr/testify/suite"
+)
+
+type StoreTestSuite struct {
+	suite.Suite
+	Stores map[string]Store
+}
+
+func (suite *StoreTestSuite) SetupSuite() {
+	suite.Stores = make(map[string]Store)
+	inMemoryStore := NewInMemoryStore()
+	suite.Stores["InMemory"] = inMemoryStore
+}
+
+func (suite *StoreTestSuite) TestAllStores() {
+	for key, store := range suite.Stores {
+		err := store.Set("x", 1)
+		suite.Nil(err, fmt.Sprintf("able to create a new key using %s store", key))
+
+		value, err := store.Get("x")
+		suite.Nil(err, "able to get a key")
+		suite.Equal(1, value, fmt.Sprintf("able to get a key using %s store", key))
+
+		err = store.Set("x", 2)
+		suite.Nil(err, fmt.Sprintf("able to update an existing key using %s store", key))
+
+		value, err = store.Get("x")
+		suite.Nil(err, fmt.Sprintf("able to get a key after update using %s store", key))
+		suite.Equal(2, value, fmt.Sprintf("able to get a key after update using %s store", key))
+
+		err = store.Delete("x")
+		suite.Nil(err, fmt.Sprintf("able to delete a key using %s store", key))
+
+		value, err = store.Get("x")
+		suite.NotNil(err, fmt.Sprintf("error getting deleted key using %s store", key))
+		suite.Nil(value, fmt.Sprintf("error getting deleted key using %s store", key))
+
+		err = store.Delete("x")
+		suite.NotNil(err, fmt.Sprintf("error deleting already-deleted key using %s store", key))
+	}
+}
+
+func TestStoreTestSuite(t *testing.T) {
+	suite.Run(t, new(StoreTestSuite))
+}

--- a/pkg/chartmuseum/router/router.go
+++ b/pkg/chartmuseum/router/router.go
@@ -30,6 +30,7 @@ type (
 		ContextPath   string
 		TlsCert       string
 		TlsKey        string
+		PathPrefix    string
 		EnableMetrics bool
 		AnonymousGet  bool
 	}
@@ -39,7 +40,11 @@ type (
 func NewRouter(options RouterOptions) *Router {
 	gin.SetMode(gin.ReleaseMode)
 	engine := gin.New()
-	engine.Use(location.Default(), ginrequestid.RequestId(), loggingMiddleware(options.Logger), gin.Recovery())
+
+	// Middleware
+	engine.Use(location.Default(), ginrequestid.RequestId(), loggingMiddleware(options.Logger, options.PathPrefix),
+		gin.Recovery(), prefixPathMiddleware(engine, options.PathPrefix))
+
 	if options.EnableMetrics {
 		p := ginprometheus.NewPrometheus("chartmuseum")
 		p.ReqCntURLLabelMappingFn = mapURLWithParamsBackToRouteTemplate

--- a/pkg/chartmuseum/server.go
+++ b/pkg/chartmuseum/server.go
@@ -48,7 +48,7 @@ func NewServer(options ServerOptions) (Server, error) {
 		return nil, err
 	}
 
-	router := cm_router.NewRouter(cm_router.RouterOptions{
+	routerOptions := cm_router.RouterOptions{
 		Logger:        logger,
 		Username:      options.Username,
 		Password:      options.Password,
@@ -57,7 +57,12 @@ func NewServer(options ServerOptions) (Server, error) {
 		TlsKey:        options.TlsKey,
 		EnableMetrics: options.EnableMetrics,
 		AnonymousGet:  options.AnonymousGet,
-	})
+	}
+	if options.EnableMultiTenancy {
+		routerOptions.PathPrefix = mt.PathPrefix
+	}
+
+	router := cm_router.NewRouter(routerOptions)
 
 	var server Server
 

--- a/pkg/chartmuseum/server.go
+++ b/pkg/chartmuseum/server.go
@@ -62,6 +62,7 @@ func NewServer(options ServerOptions) (Server, error) {
 	var server Server
 
 	if options.EnableMultiTenancy {
+		logger.Debug("Multitenancy enabled")
 		server, err = mt.NewMultiTenantServer(mt.MultiTenantServerOptions{
 			Logger:         logger,
 			Router:         router,

--- a/pkg/chartmuseum/server.go
+++ b/pkg/chartmuseum/server.go
@@ -1,6 +1,7 @@
 package chartmuseum
 
 import (
+	"github.com/kubernetes-helm/chartmuseum/pkg/cache"
 	cm_logger "github.com/kubernetes-helm/chartmuseum/pkg/chartmuseum/logger"
 	cm_router "github.com/kubernetes-helm/chartmuseum/pkg/chartmuseum/router"
 	mt "github.com/kubernetes-helm/chartmuseum/pkg/chartmuseum/server/multitenant"
@@ -57,6 +58,8 @@ func NewServer(options ServerOptions) (Server, error) {
 		AnonymousGet:  options.AnonymousGet,
 	})
 
+	store := cache.NewInMemoryStore()
+
 	var server Server
 
 	if options.EnableMultiTenancy {
@@ -64,12 +67,14 @@ func NewServer(options ServerOptions) (Server, error) {
 			Logger:         logger,
 			Router:         router,
 			StorageBackend: options.StorageBackend,
+			Cache:          store,
 		})
 	} else {
 		server, err = st.NewSingleTenantServer(st.SingleTenantServerOptions{
 			Logger:                 logger,
 			Router:                 router,
 			StorageBackend:         options.StorageBackend,
+			Cache:                  store,
 			EnableAPI:              options.EnableAPI,
 			AllowOverwrite:         options.AllowOverwrite,
 			GenIndex:               options.GenIndex,

--- a/pkg/chartmuseum/server.go
+++ b/pkg/chartmuseum/server.go
@@ -13,6 +13,7 @@ type (
 	// ServerOptions are options for constructing a Server
 	ServerOptions struct {
 		StorageBackend         storage.Backend
+		Cache                  cache.Store
 		ChartURL               string
 		TlsCert                string
 		TlsKey                 string
@@ -58,8 +59,6 @@ func NewServer(options ServerOptions) (Server, error) {
 		AnonymousGet:  options.AnonymousGet,
 	})
 
-	store := cache.NewInMemoryStore()
-
 	var server Server
 
 	if options.EnableMultiTenancy {
@@ -67,14 +66,14 @@ func NewServer(options ServerOptions) (Server, error) {
 			Logger:         logger,
 			Router:         router,
 			StorageBackend: options.StorageBackend,
-			Cache:          store,
+			Cache:          options.Cache,
 		})
 	} else {
 		server, err = st.NewSingleTenantServer(st.SingleTenantServerOptions{
 			Logger:                 logger,
 			Router:                 router,
 			StorageBackend:         options.StorageBackend,
-			Cache:                  store,
+			Cache:                  options.Cache,
 			EnableAPI:              options.EnableAPI,
 			AllowOverwrite:         options.AllowOverwrite,
 			GenIndex:               options.GenIndex,

--- a/pkg/chartmuseum/server/multitenant/handlers.go
+++ b/pkg/chartmuseum/server/multitenant/handlers.go
@@ -1,6 +1,11 @@
 package multitenant
 
 import (
+	"fmt"
+	"strings"
+
+	"github.com/kubernetes-helm/chartmuseum/pkg/repo"
+
 	"github.com/gin-gonic/gin"
 )
 
@@ -22,4 +27,62 @@ var (
 
 func (server *MultiTenantServer) defaultHandler(c *gin.Context) {
 	c.Data(200, "text/html", warningHTML)
+}
+
+func (server *MultiTenantServer) getIndexFileRequestHandler(c *gin.Context) {
+	orgName := c.Param("org")
+	repoName := c.Param("repo")
+	prefix := fmt.Sprintf("%s/%s", orgName, repoName)
+
+	objects, err := server.StorageBackend.ListObjects(prefix)
+	if err != nil {
+		c.JSON(500, gin.H{"error": fmt.Sprintf("%s", err)})
+		return
+	}
+
+	index := repo.NewIndex("")
+	for _, object := range objects {
+		op := object.Path
+		objectPath := fmt.Sprintf("%s/%s", prefix, op)
+		object, err = server.StorageBackend.GetObject(objectPath)
+		if err != nil {
+			// TODO handle err
+			continue
+		}
+		chartVersion, err := repo.ChartVersionFromStorageObject(object)
+		if err != nil {
+			// TODO handle err
+			continue
+		}
+		chartVersion.URLs[0] = fmt.Sprintf("charts/%s", op)
+		index.AddEntry(chartVersion)
+	}
+
+	index.Regenerate()
+	c.Data(200, repo.IndexFileContentType, index.Raw)
+}
+
+func (server *MultiTenantServer) getStorageObjectRequestHandler(c *gin.Context) {
+	orgName := c.Param("org")
+	repoName := c.Param("repo")
+	prefix := fmt.Sprintf("%s/%s", orgName, repoName)
+
+	filename := c.Param("filename")
+	isChartPackage := strings.HasSuffix(filename, repo.ChartPackageFileExtension)
+	isProvenanceFile := strings.HasSuffix(filename, repo.ProvenanceFileExtension)
+	if !isChartPackage && !isProvenanceFile {
+		c.JSON(500, gin.H{"error": "unsupported file extension"})
+		return
+	}
+	objectPath := fmt.Sprintf("%s/%s", prefix, filename)
+	object, err := server.StorageBackend.GetObject(objectPath)
+	if err != nil {
+		c.JSON(404, gin.H{"error": "not found"})
+		return
+	}
+	if isProvenanceFile {
+		c.Data(200, repo.ProvenanceFileContentType, object.Content)
+		return
+	}
+	c.Data(200, repo.ChartPackageContentType, object.Content)
 }

--- a/pkg/chartmuseum/server/multitenant/handlers.go
+++ b/pkg/chartmuseum/server/multitenant/handlers.go
@@ -18,7 +18,7 @@ var (
 <body>
 <h1>WARNING</h1>
 <p>This ChartMuseum install is running in multitenancy mode.</p>
-<p>This feature is still and progress, and is not considered stable.</p>
+<p>This feature is still a work in progress, and is not considered stable.</p>
 <p>Please run without the --multitenant flag to disable this.</p>
 </body>
 </html>

--- a/pkg/chartmuseum/server/multitenant/handlers.go
+++ b/pkg/chartmuseum/server/multitenant/handlers.go
@@ -1,0 +1,25 @@
+package multitenant
+
+import (
+	"github.com/gin-gonic/gin"
+)
+
+var (
+	warningHTML = []byte(`<!DOCTYPE html>
+<html>
+<head>
+<title>WARNING</title>
+</head>
+<body>
+<h1>WARNING</h1>
+<p>This ChartMuseum install is running in multitenancy mode.</p>
+<p>This feature is still and progress, and is not considered stable.</p>
+<p>Please run without the --multitenant flag to disable this.</p>
+</body>
+</html>
+	`)
+)
+
+func (server *MultiTenantServer) defaultHandler(c *gin.Context) {
+	c.Data(200, "text/html", warningHTML)
+}

--- a/pkg/chartmuseum/server/multitenant/routes.go
+++ b/pkg/chartmuseum/server/multitenant/routes.go
@@ -1,0 +1,5 @@
+package multitenant
+
+func (server *MultiTenantServer) setRoutes() {
+	server.Router.Groups.ReadAccess.GET("/", server.defaultHandler)
+}

--- a/pkg/chartmuseum/server/multitenant/routes.go
+++ b/pkg/chartmuseum/server/multitenant/routes.go
@@ -1,5 +1,10 @@
 package multitenant
 
 func (server *MultiTenantServer) setRoutes() {
-	server.Router.Groups.ReadAccess.GET("/", server.defaultHandler)
+	// Server Info
+	//server.Router.Groups.ReadAccess.GET("/", server.defaultHandler)
+
+	// Helm Chart Repository
+	server.Router.Groups.ReadAccess.GET("/r/:org/:repo/index.yaml", server.getIndexFileRequestHandler)
+	server.Router.Groups.ReadAccess.GET("/r/:org/:repo/charts/:filename", server.getStorageObjectRequestHandler)
 }

--- a/pkg/chartmuseum/server/multitenant/routes.go
+++ b/pkg/chartmuseum/server/multitenant/routes.go
@@ -2,9 +2,9 @@ package multitenant
 
 func (server *MultiTenantServer) setRoutes() {
 	// Server Info
-	server.Router.Groups.ReadAccess.GET("/", server.defaultHandler)
+	server.Router.Groups.ReadAccess.GET(p("/"), server.defaultHandler)
 
 	// Helm Chart Repository
-	server.Router.Groups.ReadAccess.GET("/r/:org/:repo/index.yaml", server.getIndexFileRequestHandler)
-	server.Router.Groups.ReadAccess.GET("/r/:org/:repo/charts/:filename", server.getStorageObjectRequestHandler)
+	server.Router.Groups.ReadAccess.GET(p("/:org/:repo/index.yaml"), server.getIndexFileRequestHandler)
+	server.Router.Groups.ReadAccess.GET(p("/:org/:repo/charts/:filename"), server.getStorageObjectRequestHandler)
 }

--- a/pkg/chartmuseum/server/multitenant/routes.go
+++ b/pkg/chartmuseum/server/multitenant/routes.go
@@ -2,7 +2,7 @@ package multitenant
 
 func (server *MultiTenantServer) setRoutes() {
 	// Server Info
-	//server.Router.Groups.ReadAccess.GET("/", server.defaultHandler)
+	server.Router.Groups.ReadAccess.GET("/", server.defaultHandler)
 
 	// Helm Chart Repository
 	server.Router.Groups.ReadAccess.GET("/r/:org/:repo/index.yaml", server.getIndexFileRequestHandler)

--- a/pkg/chartmuseum/server/multitenant/server.go
+++ b/pkg/chartmuseum/server/multitenant/server.go
@@ -1,10 +1,18 @@
 package multitenant
 
 import (
+	"math/rand"
+	pathutil "path"
+	"time"
+
 	"github.com/kubernetes-helm/chartmuseum/pkg/cache"
 	cm_logger "github.com/kubernetes-helm/chartmuseum/pkg/chartmuseum/logger"
 	cm_router "github.com/kubernetes-helm/chartmuseum/pkg/chartmuseum/router"
 	"github.com/kubernetes-helm/chartmuseum/pkg/storage"
+)
+
+var (
+	PathPrefix string
 )
 
 type (
@@ -42,4 +50,25 @@ func NewMultiTenantServer(options MultiTenantServerOptions) (*MultiTenantServer,
 // Listen TODO
 func (server *MultiTenantServer) Listen(port int) {
 	server.Router.Start(port)
+}
+
+// simple helper to prepend the necessary path prefix for each route
+func p(path string) string {
+	return pathutil.Join(PathPrefix, path)
+}
+
+// make the PathPrefix pretty much unguessable,
+// incoming requests with this prefix will not be logged
+func setPathPrefix() {
+	charset := "abcdefghijklmnopqrstuvwxyz0123456789"
+	b := make([]byte, 40)
+	seededRand := rand.New(rand.NewSource(time.Now().UnixNano()))
+	for i := range b {
+		b[i] = charset[seededRand.Intn(len(charset))]
+	}
+	PathPrefix = "/" + string(b)
+}
+
+func init() {
+	setPathPrefix()
 }

--- a/pkg/chartmuseum/server/multitenant/server.go
+++ b/pkg/chartmuseum/server/multitenant/server.go
@@ -1,6 +1,7 @@
 package multitenant
 
 import (
+	"github.com/kubernetes-helm/chartmuseum/pkg/cache"
 	cm_logger "github.com/kubernetes-helm/chartmuseum/pkg/chartmuseum/logger"
 	cm_router "github.com/kubernetes-helm/chartmuseum/pkg/chartmuseum/router"
 	"github.com/kubernetes-helm/chartmuseum/pkg/storage"
@@ -12,6 +13,7 @@ type (
 		Logger         *cm_logger.Logger
 		Router         *cm_router.Router
 		StorageBackend storage.Backend
+		Cache          cache.Store
 	}
 
 	// MultiTenantServerOptions are options for constructing a MultiTenantServer
@@ -19,6 +21,7 @@ type (
 		Logger         *cm_logger.Logger
 		Router         *cm_router.Router
 		StorageBackend storage.Backend
+		Cache          cache.Store
 	}
 )
 
@@ -28,6 +31,7 @@ func NewMultiTenantServer(options MultiTenantServerOptions) (*MultiTenantServer,
 		Logger:         options.Logger,
 		Router:         options.Router,
 		StorageBackend: options.StorageBackend,
+		Cache:          options.Cache,
 	}
 
 	server.setRoutes()

--- a/pkg/chartmuseum/server/multitenant/server.go
+++ b/pkg/chartmuseum/server/multitenant/server.go
@@ -1,0 +1,41 @@
+package multitenant
+
+import (
+	cm_logger "github.com/kubernetes-helm/chartmuseum/pkg/chartmuseum/logger"
+	cm_router "github.com/kubernetes-helm/chartmuseum/pkg/chartmuseum/router"
+	"github.com/kubernetes-helm/chartmuseum/pkg/storage"
+)
+
+type (
+	// MultiTenantServer contains a Logger, Router, storage backend and object cache
+	MultiTenantServer struct {
+		Logger         *cm_logger.Logger
+		Router         *cm_router.Router
+		StorageBackend storage.Backend
+	}
+
+	// MultiTenantServerOptions are options for constructing a MultiTenantServer
+	MultiTenantServerOptions struct {
+		Logger         *cm_logger.Logger
+		Router         *cm_router.Router
+		StorageBackend storage.Backend
+	}
+)
+
+// NewMultiTenantServer creates a new MultiTenantServer instance
+func NewMultiTenantServer(options MultiTenantServerOptions) (*MultiTenantServer, error) {
+	server := &MultiTenantServer{
+		Logger:         options.Logger,
+		Router:         options.Router,
+		StorageBackend: options.StorageBackend,
+	}
+
+	server.setRoutes()
+
+	return server, nil
+}
+
+// Listen TODO
+func (server *MultiTenantServer) Listen(port int) {
+	server.Router.Start(port)
+}

--- a/pkg/chartmuseum/server/multitenant/server_test.go
+++ b/pkg/chartmuseum/server/multitenant/server_test.go
@@ -9,6 +9,7 @@ import (
 	"testing"
 	"time"
 
+	"github.com/kubernetes-helm/chartmuseum/pkg/cache"
 	cm_logger "github.com/kubernetes-helm/chartmuseum/pkg/chartmuseum/logger"
 	cm_router "github.com/kubernetes-helm/chartmuseum/pkg/chartmuseum/router"
 	"github.com/kubernetes-helm/chartmuseum/pkg/storage"
@@ -57,6 +58,7 @@ func (suite *MultiTenantServerTestSuite) SetupSuite() {
 		Logger:         logger,
 		Router:         router,
 		StorageBackend: backend,
+		Cache:          cache.NewInMemoryStore(),
 	})
 	suite.NotNil(server)
 	suite.Nil(err, "no error creating new multitenant server")

--- a/pkg/chartmuseum/server/multitenant/server_test.go
+++ b/pkg/chartmuseum/server/multitenant/server_test.go
@@ -1,0 +1,82 @@
+package multitenant
+
+import (
+	"fmt"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"os"
+	"testing"
+	"time"
+
+	cm_logger "github.com/kubernetes-helm/chartmuseum/pkg/chartmuseum/logger"
+	cm_router "github.com/kubernetes-helm/chartmuseum/pkg/chartmuseum/router"
+	"github.com/kubernetes-helm/chartmuseum/pkg/storage"
+
+	"github.com/gin-gonic/gin"
+	"github.com/stretchr/testify/suite"
+)
+
+type MultiTenantServerTestSuite struct {
+	suite.Suite
+	Server               *MultiTenantServer
+	TempDirectory        string
+	TestTarballFilename  string
+	TestProvfileFilename string
+}
+
+func (suite *MultiTenantServerTestSuite) doRequest(stype string, method string, urlStr string, body io.Reader, contentType string) gin.ResponseWriter {
+	c, _ := gin.CreateTestContext(httptest.NewRecorder())
+	c.Request, _ = http.NewRequest(method, urlStr, body)
+	if contentType != "" {
+		c.Request.Header.Set("Content-Type", contentType)
+	}
+
+	switch stype {
+	case "anonymous":
+		suite.Server.Router.HandleContext(c)
+	}
+
+	return c.Writer
+}
+
+func (suite *MultiTenantServerTestSuite) SetupSuite() {
+	timestamp := time.Now().Format("20060102150405")
+	suite.TempDirectory = fmt.Sprintf("../../../../.test/chartmuseum-multitenant-server/%s", timestamp)
+
+	backend := storage.Backend(storage.NewLocalFilesystemBackend(suite.TempDirectory))
+
+	logger, err := cm_logger.NewLogger(cm_logger.LoggerOptions{})
+	suite.Nil(err, "no error creating logger")
+
+	router := cm_router.NewRouter(cm_router.RouterOptions{
+		Logger: logger,
+	})
+
+	server, err := NewMultiTenantServer(MultiTenantServerOptions{
+		Logger:         logger,
+		Router:         router,
+		StorageBackend: backend,
+	})
+	suite.NotNil(server)
+	suite.Nil(err, "no error creating new multitenant server")
+
+	suite.Server = server
+}
+
+func (suite *MultiTenantServerTestSuite) TearDownSuite() {
+	err := os.RemoveAll(suite.TempDirectory)
+	suite.Nil(err, "no error deleting temp directory for local storage")
+}
+
+func (suite *MultiTenantServerTestSuite) TestRoutes() {
+	var res gin.ResponseWriter
+
+	// GET /
+	res = suite.doRequest("anonymous", "GET", "/", nil, "")
+	suite.Equal(200, res.Status(), "200 GET /")
+}
+
+func TestMultiTenantServerTestSuite(t *testing.T) {
+	suite.Run(t, new(MultiTenantServerTestSuite))
+}

--- a/pkg/chartmuseum/server/singletenant/cache.go
+++ b/pkg/chartmuseum/server/singletenant/cache.go
@@ -110,7 +110,7 @@ func (server *SingleTenantServer) syncRepositoryIndex(log cm_logger.LoggingFn) (
 
 func (server *SingleTenantServer) fetchChartsInStorage(log cm_logger.LoggingFn) ([]storage.Object, error) {
 	log(cm_logger.DebugLevel, "Fetching chart list from storage")
-	allObjects, err := server.StorageBackend.ListObjects()
+	allObjects, err := server.StorageBackend.ListObjects("")
 	if err != nil {
 		return []storage.Object{}, err
 	}

--- a/pkg/chartmuseum/server/singletenant/server.go
+++ b/pkg/chartmuseum/server/singletenant/server.go
@@ -5,11 +5,13 @@ import (
 	"os"
 	"sync"
 
-	"github.com/gin-gonic/gin"
+	"github.com/kubernetes-helm/chartmuseum/pkg/cache"
 	cm_logger "github.com/kubernetes-helm/chartmuseum/pkg/chartmuseum/logger"
 	cm_router "github.com/kubernetes-helm/chartmuseum/pkg/chartmuseum/router"
 	"github.com/kubernetes-helm/chartmuseum/pkg/repo"
 	"github.com/kubernetes-helm/chartmuseum/pkg/storage"
+
+	"github.com/gin-gonic/gin"
 )
 
 var (
@@ -24,6 +26,7 @@ type (
 		Router                  *cm_router.Router
 		RepositoryIndex         *repo.Index
 		StorageBackend          storage.Backend
+		Cache                   cache.Store
 		StorageCache            []storage.Object
 		AllowOverwrite          bool
 		APIEnabled              bool
@@ -41,6 +44,7 @@ type (
 		Logger                 *cm_logger.Logger
 		Router                 *cm_router.Router
 		StorageBackend         storage.Backend
+		Cache                  cache.Store
 		EnableAPI              bool
 		AllowOverwrite         bool
 		GenIndex               bool
@@ -58,6 +62,7 @@ func NewSingleTenantServer(options SingleTenantServerOptions) (*SingleTenantServ
 		Router:                 options.Router,
 		RepositoryIndex:        repo.NewIndex(options.ChartURL),
 		StorageBackend:         options.StorageBackend,
+		Cache:                  options.Cache,
 		StorageCache:           []storage.Object{},
 		APIEnabled:             options.EnableAPI,
 		AllowOverwrite:         options.AllowOverwrite,

--- a/pkg/chartmuseum/server/singletenant/server_test.go
+++ b/pkg/chartmuseum/server/singletenant/server_test.go
@@ -13,6 +13,7 @@ import (
 	"testing"
 	"time"
 
+	"github.com/kubernetes-helm/chartmuseum/pkg/cache"
 	"github.com/kubernetes-helm/chartmuseum/pkg/storage"
 	cm_logger "github.com/kubernetes-helm/chartmuseum/pkg/chartmuseum/logger"
 	cm_router "github.com/kubernetes-helm/chartmuseum/pkg/chartmuseum/router"
@@ -101,6 +102,7 @@ func (suite *SingleTenantServerTestSuite) SetupSuite() {
 		Logger: logger,
 		Router: router,
 		StorageBackend: backend,
+		Cache: cache.NewInMemoryStore(),
 		EnableAPI: true,
 	})
 	suite.NotNil(server)
@@ -120,6 +122,7 @@ func (suite *SingleTenantServerTestSuite) SetupSuite() {
 		Logger: logger,
 		Router: router,
 		StorageBackend: backend,
+		Cache: cache.NewInMemoryStore(),
 		EnableAPI: true,
 	})
 	suite.NotNil(server)
@@ -142,6 +145,7 @@ func (suite *SingleTenantServerTestSuite) SetupSuite() {
 		Logger: logger,
 		Router: router,
 		StorageBackend: backend,
+		Cache: cache.NewInMemoryStore(),
 		EnableAPI: true,
 		IndexLimit: 10,
 		ChartPostFormFieldName: "chart",
@@ -159,6 +163,7 @@ func (suite *SingleTenantServerTestSuite) SetupSuite() {
 		Logger: logger,
 		Router: router,
 		StorageBackend: backend,
+		Cache: cache.NewInMemoryStore(),
 		EnableAPI: false,
 	})
 	suite.Nil(err, "no error creating new server, logJson=false, debug=true, disabled=true, overwrite=false")
@@ -173,6 +178,7 @@ func (suite *SingleTenantServerTestSuite) SetupSuite() {
 		Logger: logger,
 		Router: router,
 		StorageBackend: backend,
+		Cache: cache.NewInMemoryStore(),
 		EnableAPI: true,
 		AllowOverwrite: true,
 		ChartPostFormFieldName: "chart",
@@ -191,6 +197,7 @@ func (suite *SingleTenantServerTestSuite) SetupSuite() {
 		Logger: logger,
 		Router: router,
 		StorageBackend: backend,
+		Cache: cache.NewInMemoryStore(),
 		EnableAPI: true,
 		AllowOverwrite: true,
 	})
@@ -233,6 +240,7 @@ func (suite *SingleTenantServerTestSuite) SetupSuite() {
 		Logger: logger,
 		Router: router,
 		StorageBackend: brokenBackend,
+		Cache: cache.NewInMemoryStore(),
 		EnableAPI: true,
 	})
 	suite.Nil(err, "no error creating new server, logJson=false, debug=true, disabled=false, overwrite=false")
@@ -301,6 +309,7 @@ func (suite *SingleTenantServerTestSuite) TestGenIndex() {
 		Logger: logger,
 		Router: router,
 		StorageBackend: suite.Server.StorageBackend,
+		Cache: cache.NewInMemoryStore(),
 		GenIndex: true,
 	})
 	suite.Equal("exited 0", suite.LastCrashMessage, "no error with --gen-index")

--- a/pkg/chartmuseum/server_test.go
+++ b/pkg/chartmuseum/server_test.go
@@ -32,8 +32,14 @@ func (suite *ServerTestSuite) TestNewServer() {
 	serverOptions := ServerOptions{
 		StorageBackend: suite.Backend,
 	}
-	server, err := NewServer(serverOptions)
-	suite.NotNil(server)
+
+	singleTenantServer, err := NewServer(serverOptions)
+	suite.NotNil(singleTenantServer)
+	suite.Nil(err)
+
+	serverOptions.EnableMultiTenancy = true
+	multiTenantServer, err := NewServer(serverOptions)
+	suite.NotNil(multiTenantServer)
 	suite.Nil(err)
 }
 

--- a/pkg/storage/alibaba.go
+++ b/pkg/storage/alibaba.go
@@ -57,13 +57,13 @@ func NewAlibabaCloudOSSBackend(bucket string, prefix string, endpoint string, ss
 }
 
 // ListObjects lists all objects in Alibaba Cloud OSS bucket, at prefix
-func (b AlibabaCloudOSSBackend) ListObjects() ([]Object, error) {
+func (b AlibabaCloudOSSBackend) ListObjects(prefix string) ([]Object, error) {
 	var objects []Object
 
-	prefix := oss.Prefix(b.Prefix)
+	pfx := oss.Prefix(b.Prefix)
 	marker := oss.Marker("")
 	for {
-		lor, err := b.Bucket.ListObjects(oss.MaxKeys(50), marker, prefix)
+		lor, err := b.Bucket.ListObjects(oss.MaxKeys(50), marker, pfx)
 		if err != nil {
 			return objects, err
 		}
@@ -82,7 +82,7 @@ func (b AlibabaCloudOSSBackend) ListObjects() ([]Object, error) {
 		if !lor.IsTruncated {
 			break
 		}
-		prefix = oss.Prefix(lor.Prefix)
+		pfx = oss.Prefix(lor.Prefix)
 		marker = oss.Marker(lor.NextMarker)
 	}
 

--- a/pkg/storage/alibaba.go
+++ b/pkg/storage/alibaba.go
@@ -60,15 +60,16 @@ func NewAlibabaCloudOSSBackend(bucket string, prefix string, endpoint string, ss
 func (b AlibabaCloudOSSBackend) ListObjects(prefix string) ([]Object, error) {
 	var objects []Object
 
-	pfx := oss.Prefix(b.Prefix)
+	prefix = pathutil.Join(b.Prefix, prefix)
+	ossPrefix := oss.Prefix(prefix)
 	marker := oss.Marker("")
 	for {
-		lor, err := b.Bucket.ListObjects(oss.MaxKeys(50), marker, pfx)
+		lor, err := b.Bucket.ListObjects(oss.MaxKeys(50), marker, ossPrefix)
 		if err != nil {
 			return objects, err
 		}
 		for _, obj := range lor.Objects {
-			path := removePrefixFromObjectPath(b.Prefix, obj.Key)
+			path := removePrefixFromObjectPath(prefix, obj.Key)
 			if objectPathIsInvalid(path) {
 				continue
 			}
@@ -82,7 +83,7 @@ func (b AlibabaCloudOSSBackend) ListObjects(prefix string) ([]Object, error) {
 		if !lor.IsTruncated {
 			break
 		}
-		pfx = oss.Prefix(lor.Prefix)
+		ossPrefix = oss.Prefix(lor.Prefix)
 		marker = oss.Marker(lor.NextMarker)
 	}
 

--- a/pkg/storage/alibaba_test.go
+++ b/pkg/storage/alibaba_test.go
@@ -56,14 +56,14 @@ func (suite *AlibabaTestSuite) TearDownSuite() {
 }
 
 func (suite *AlibabaTestSuite) TestListObjects() {
-	_, err := suite.BrokenAlibabaOSSBackend.ListObjects()
+	_, err := suite.BrokenAlibabaOSSBackend.ListObjects("")
 	suite.NotNil(err, "cannot list objects with bad bucket")
 
-	objs, err := suite.NoPrefixAlibabaOSSBackend.ListObjects()
+	objs, err := suite.NoPrefixAlibabaOSSBackend.ListObjects("")
 	suite.Nil(err, "can list objects with good bucket, no prefix")
 	suite.Equal(len(objs), testCount, "able to list objects")
 
-	objs, err = suite.SSEAlibabaOSSBackend.ListObjects()
+	objs, err = suite.SSEAlibabaOSSBackend.ListObjects("")
 	suite.Nil(err, "can list objects with good bucket, SSE")
 	suite.Equal(len(objs), testCount, "able to list objects")
 }

--- a/pkg/storage/amazon.go
+++ b/pkg/storage/amazon.go
@@ -42,7 +42,7 @@ func NewAmazonS3Backend(bucket string, prefix string, region string, endpoint st
 }
 
 // ListObjects lists all objects in Amazon S3 bucket, at prefix
-func (b AmazonS3Backend) ListObjects() ([]Object, error) {
+func (b AmazonS3Backend) ListObjects(prefix string) ([]Object, error) {
 	var objects []Object
 	s3Input := &s3.ListObjectsInput{
 		Bucket: aws.String(b.Bucket),

--- a/pkg/storage/amazon.go
+++ b/pkg/storage/amazon.go
@@ -44,9 +44,10 @@ func NewAmazonS3Backend(bucket string, prefix string, region string, endpoint st
 // ListObjects lists all objects in Amazon S3 bucket, at prefix
 func (b AmazonS3Backend) ListObjects(prefix string) ([]Object, error) {
 	var objects []Object
+	prefix = pathutil.Join(b.Prefix, prefix)
 	s3Input := &s3.ListObjectsInput{
 		Bucket: aws.String(b.Bucket),
-		Prefix: aws.String(b.Prefix),
+		Prefix: aws.String(prefix),
 	}
 	for {
 		s3Result, err := b.Client.ListObjects(s3Input)
@@ -54,7 +55,7 @@ func (b AmazonS3Backend) ListObjects(prefix string) ([]Object, error) {
 			return objects, err
 		}
 		for _, obj := range s3Result.Contents {
-			path := removePrefixFromObjectPath(b.Prefix, *obj.Key)
+			path := removePrefixFromObjectPath(prefix, *obj.Key)
 			if objectPathIsInvalid(path) {
 				continue
 			}

--- a/pkg/storage/amazon_test.go
+++ b/pkg/storage/amazon_test.go
@@ -45,13 +45,13 @@ func (suite *AmazonTestSuite) TearDownSuite() {
 }
 
 func (suite *AmazonTestSuite) TestListObjects() {
-	_, err := suite.BrokenAmazonS3Backend.ListObjects()
+	_, err := suite.BrokenAmazonS3Backend.ListObjects("")
 	suite.NotNil(err, "cannot list objects with bad bucket")
 
-	_, err = suite.NoPrefixAmazonS3Backend.ListObjects()
+	_, err = suite.NoPrefixAmazonS3Backend.ListObjects("")
 	suite.Nil(err, "can list objects with good bucket, no prefix")
 
-	_, err = suite.SSEAmazonS3Backend.ListObjects()
+	_, err = suite.SSEAmazonS3Backend.ListObjects("")
 	suite.Nil(err, "can list objects with good bucket, SSE")
 }
 

--- a/pkg/storage/google.go
+++ b/pkg/storage/google.go
@@ -37,7 +37,7 @@ func NewGoogleCSBackend(bucket string, prefix string) *GoogleCSBackend {
 }
 
 // ListObjects lists all objects in Google Cloud Storage bucket, at prefix
-func (b GoogleCSBackend) ListObjects() ([]Object, error) {
+func (b GoogleCSBackend) ListObjects(prefix string) ([]Object, error) {
 	var objects []Object
 	it := b.Client.Objects(b.Context, b.Query)
 	for {

--- a/pkg/storage/google.go
+++ b/pkg/storage/google.go
@@ -12,7 +12,6 @@ import (
 // GoogleCSBackend is a storage backend for Google Cloud Storage
 type GoogleCSBackend struct {
 	Prefix  string
-	Query   *storage.Query
 	Client  *storage.BucketHandle
 	Context context.Context
 }
@@ -26,10 +25,8 @@ func NewGoogleCSBackend(bucket string, prefix string) *GoogleCSBackend {
 	}
 	bucketHandle := client.Bucket(bucket)
 	prefix = cleanPrefix(prefix)
-	listQuery := storage.Query{Prefix: prefix}
 	b := &GoogleCSBackend{
 		Prefix:  prefix,
-		Query:   &listQuery,
 		Client:  bucketHandle,
 		Context: ctx,
 	}
@@ -39,7 +36,11 @@ func NewGoogleCSBackend(bucket string, prefix string) *GoogleCSBackend {
 // ListObjects lists all objects in Google Cloud Storage bucket, at prefix
 func (b GoogleCSBackend) ListObjects(prefix string) ([]Object, error) {
 	var objects []Object
-	it := b.Client.Objects(b.Context, b.Query)
+	prefix = pathutil.Join(b.Prefix, prefix)
+	listQuery := &storage.Query{
+		Prefix: prefix,
+	}
+	it := b.Client.Objects(b.Context, listQuery)
 	for {
 		attrs, err := it.Next()
 		if err == iterator.Done {
@@ -48,7 +49,7 @@ func (b GoogleCSBackend) ListObjects(prefix string) ([]Object, error) {
 		if err != nil {
 			return objects, err
 		}
-		path := removePrefixFromObjectPath(b.Prefix, attrs.Name)
+		path := removePrefixFromObjectPath(prefix, attrs.Name)
 		if objectPathIsInvalid(path) {
 			continue
 		}

--- a/pkg/storage/google_test.go
+++ b/pkg/storage/google_test.go
@@ -33,10 +33,10 @@ func (suite *GoogleTestSuite) TearDownSuite() {
 }
 
 func (suite *GoogleTestSuite) TestListObjects() {
-	_, err := suite.BrokenGoogleCSBackend.ListObjects()
+	_, err := suite.BrokenGoogleCSBackend.ListObjects("")
 	suite.NotNil(err, "cannot list objects with bad bucket")
 
-	_, err = suite.NoPrefixGoogleCSBackend.ListObjects()
+	_, err = suite.NoPrefixGoogleCSBackend.ListObjects("")
 	suite.Nil(err, "can list objects with good bucket, no prefix")
 }
 

--- a/pkg/storage/local.go
+++ b/pkg/storage/local.go
@@ -25,9 +25,9 @@ func NewLocalFilesystemBackend(rootDirectory string) *LocalFilesystemBackend {
 }
 
 // ListObjects lists all objects in root directory (depth 1)
-func (b LocalFilesystemBackend) ListObjects() ([]Object, error) {
+func (b LocalFilesystemBackend) ListObjects(prefix string) ([]Object, error) {
 	var objects []Object
-	files, err := ioutil.ReadDir(b.RootDirectory)
+	files, err := ioutil.ReadDir(pathutil.Join(b.RootDirectory, prefix))
 	if err != nil {
 		return objects, err
 	}

--- a/pkg/storage/local_test.go
+++ b/pkg/storage/local_test.go
@@ -24,7 +24,7 @@ func (suite *LocalTestSuite) SetupSuite() {
 }
 
 func (suite *LocalTestSuite) TestListObjects() {
-	_, err := suite.LocalFilesystemBackend.ListObjects()
+	_, err := suite.LocalFilesystemBackend.ListObjects("")
 	suite.NotNil(err, "cannot list objects with bad root dir")
 }
 

--- a/pkg/storage/microsoft.go
+++ b/pkg/storage/microsoft.go
@@ -42,7 +42,7 @@ func NewMicrosoftBlobBackend(container string, prefix string) *MicrosoftBlobBack
 }
 
 // ListObjects lists all objects in Microsoft Azure Blob Storage container
-func (b MicrosoftBlobBackend) ListObjects() ([]Object, error) {
+func (b MicrosoftBlobBackend) ListObjects(prefix string) ([]Object, error) {
 	var objects []Object
 
 	if b.Container == nil {

--- a/pkg/storage/microsoft.go
+++ b/pkg/storage/microsoft.go
@@ -50,14 +50,15 @@ func (b MicrosoftBlobBackend) ListObjects(prefix string) ([]Object, error) {
 	}
 
 	var params microsoft_storage.ListBlobsParameters
-	params.Prefix = b.Prefix
+	prefix = pathutil.Join(b.Prefix, prefix)
+	params.Prefix = prefix
 	response, err := b.Container.ListBlobs(params)
 	if err != nil {
 		return objects, err
 	}
 
 	for _, blob := range response.Blobs {
-		path := removePrefixFromObjectPath(b.Prefix, blob.Name)
+		path := removePrefixFromObjectPath(prefix, blob.Name)
 		if objectPathIsInvalid(path) {
 			continue
 		}

--- a/pkg/storage/microsoft_test.go
+++ b/pkg/storage/microsoft_test.go
@@ -33,10 +33,10 @@ func (suite *MicrosoftTestSuite) TearDownSuite() {
 }
 
 func (suite *MicrosoftTestSuite) TestListObjects() {
-	_, err := suite.BrokenAzureBlobBackend.ListObjects()
+	_, err := suite.BrokenAzureBlobBackend.ListObjects("")
 	suite.NotNil(err, "cannot list objects with bad bucket")
 
-	_, err = suite.NoPrefixAzureBlobBackend.ListObjects()
+	_, err = suite.NoPrefixAzureBlobBackend.ListObjects("")
 	suite.Nil(err, "can list objects with good bucket, no prefix")
 }
 

--- a/pkg/storage/storage.go
+++ b/pkg/storage/storage.go
@@ -25,7 +25,7 @@ type (
 
 	// Backend is a generic interface for storage backends
 	Backend interface {
-		ListObjects() ([]Object, error)
+		ListObjects(prefix string) ([]Object, error)
 		GetObject(path string) (Object, error)
 		PutObject(path string, content []byte) error
 		DeleteObject(path string) error

--- a/pkg/storage/storage_test.go
+++ b/pkg/storage/storage_test.go
@@ -98,7 +98,7 @@ func (suite *StorageTestSuite) TearDownSuite() {
 
 func (suite *StorageTestSuite) TestListObjects() {
 	for key, backend := range suite.StorageBackends {
-		objects, err := backend.ListObjects()
+		objects, err := backend.ListObjects("")
 		message := fmt.Sprintf("no error listing objects using %s backend", key)
 		suite.Nil(err, message)
 		expectedNumObjects := 9


### PR DESCRIPTION
fixes #70 

index.yaml's being generated on the fly. Next PR will use an in-memory cache. A cache subpackage has also been added to support next steps.

`ListObjects` methods have a new "prefix" arg, to support listing objects from a storage backend starting at a nested location. The arg is only being used for now in `LocalFilesystemBackend`, which is the only backend this is tested with (for now).

cc @liamawhite @SlickNik @davidovich @itaysk