### PR TITLE
Add --depth option for variable storage nesting in multitenancy

### DIFF
--- a/README.md
+++ b/README.md
@@ -287,9 +287,11 @@ charts
 │   │   └── chartmuseum-0.4.0.tgz
 ```
 
-Start the server with the `--multitenant` option, pointing to the `charts/` directory:
+This represents a storage layout appropriate for `--depth=2`. The organization level can be eliminated by using `--depth=1`. Technically, you could even use `--depth=0` to get a singletenant server.
+
+Start the server with the `--multitenant` and `--depth=2` options, pointing to the `charts/` directory:
 ```
-chartmuseum --debug --port=8080 --multitenant --storage="local" --storage-local-rootdir=./charts 
+chartmuseum --debug --multitenant --depth=2 --storage="local" --storage-local-rootdir=./charts
 ```
 
 This example will provide two separate Helm Chart Repositories at the following locations:

--- a/cmd/chartmuseum/main.go
+++ b/cmd/chartmuseum/main.go
@@ -59,6 +59,7 @@ func cliHandler(c *cli.Context) {
 		AnonymousGet:           c.Bool("auth-anonymous-get"),
 		GenIndex:               c.Bool("gen-index"),
 		IndexLimit:             c.Int("index-limit"),
+		Depth:                  c.Int("depth"),
 	}
 
 	server, err := newServer(options)
@@ -160,11 +161,6 @@ func crashIfContextMissingFlags(c *cli.Context, flags []string) {
 }
 
 var cliFlags = []cli.Flag{
-	cli.BoolFlag{
-		Name:   "multitenant",
-		Usage:  "enable multitenancy (WARNING: experimental)",
-		EnvVar: "MULTITENANT",
-	},
 	cli.BoolFlag{
 		Name:   "gen-index",
 		Usage:  "generate index.yaml, print to stdout and exit",
@@ -329,5 +325,16 @@ var cliFlags = []cli.Flag{
 		Value:  "",
 		Usage:  "base context path",
 		EnvVar: "CONTEXT_PATH",
+	},
+	cli.BoolFlag{
+		Name:   "multitenant",
+		Usage:  "enable multitenancy (WARNING: experimental)",
+		EnvVar: "MULTITENANT",
+	},
+	cli.IntFlag{
+		Name:   "depth",
+		Value:  0,
+		Usage:  "levels of nested repos for multitenancy (WARNING: experimental)",
+		EnvVar: "DEPTH",
 	},
 }

--- a/glide.lock
+++ b/glide.lock
@@ -1,5 +1,5 @@
-hash: a11a56b8ad5d6673feab708670cc57052d393e236d8cc9d30044f7f2b7d96d8b
-updated: 2018-03-09T18:23:43.660725-06:00
+hash: f0805a1913b183412dc7573e074a10bdda8b485a2f8df806075338b838e58faa
+updated: 2018-03-12T23:20:55.203123-05:00
 imports:
 - name: cloud.google.com/go
   version: 3137f1def9552929c7beb11f2ac7d2dd998e4040
@@ -81,6 +81,8 @@ imports:
   - render
 - name: github.com/go-ini/ini
   version: c787282c39ac1fc618827141a1f762240def08a3
+- name: github.com/go-redis/redis
+  version: 9133634a132e00309476e2d9acbf0c8058d4c888
 - name: github.com/gobwas/glob
   version: 5ccd90ef52e1e632236f7326478d4faa74f99438
   subpackages:

--- a/glide.yaml
+++ b/glide.yaml
@@ -18,6 +18,10 @@ import:
 - package: github.com/gin-contrib/location
   version: 5220ebf8be6c350431168cbd884f2c0ace0e3f4c
 
+# Redis support
+- package: github.com/go-redis/redis
+  version: v6.10.0
+
 # Used by Microsoft Azure Blob storage backend
 - package: github.com/Azure/azure-sdk-for-go
   version: v14.0.0

--- a/pkg/cache/inmemory.go
+++ b/pkg/cache/inmemory.go
@@ -60,7 +60,6 @@ func (store *InMemoryStore) Delete(key string) error {
 		store.KeyLock.Lock()
 		delete(store.Keys, key)
 		store.KeyLock.Unlock()
-		return nil
 	}
-	return errors.New(fmt.Sprintf("Could not find key \"%s\"", key))
+	return nil
 }

--- a/pkg/cache/inmemory.go
+++ b/pkg/cache/inmemory.go
@@ -15,7 +15,7 @@ type (
 
 	// InMemoryObject represents a single in-memory key value
 	InMemoryObject struct {
-		Contents  interface{}
+		Contents  []byte
 		WriteLock *sync.Mutex
 	}
 )
@@ -30,7 +30,7 @@ func NewInMemoryStore() *InMemoryStore {
 }
 
 // Get returns an object at key
-func (store *InMemoryStore) Get(key string) (interface{}, error) {
+func (store *InMemoryStore) Get(key string) ([]byte, error) {
 	if object, ok := store.Keys[key]; ok {
 		return object.Contents, nil
 	}
@@ -38,7 +38,7 @@ func (store *InMemoryStore) Get(key string) (interface{}, error) {
 }
 
 // Set saves a new value for key
-func (store *InMemoryStore) Set(key string, contents interface{}) error {
+func (store *InMemoryStore) Set(key string, contents []byte) error {
 	if object, ok := store.Keys[key]; ok {
 		object.WriteLock.Lock()
 		object.Contents = contents

--- a/pkg/cache/redis.go
+++ b/pkg/cache/redis.go
@@ -1,0 +1,41 @@
+package cache
+
+import (
+	"github.com/go-redis/redis"
+)
+
+type (
+	// RedisStore implements the Store interface, used for storing objects in-memory
+	RedisStore struct {
+		Client *redis.Client
+	}
+
+	// RedisStoreOptions are the options for creating a new RedisStore
+	RedisStoreOptions struct {
+		Addr string
+	}
+)
+
+// NewRedisStore creates a new RedisStore
+func NewRedisStore(options *RedisStoreOptions) *RedisStore {
+	store := &RedisStore{}
+	store.Client = redis.NewClient(&redis.Options{
+		Addr: options.Addr,
+	})
+	return store
+}
+
+// Get returns an object at key
+func (store *RedisStore) Get(key string) ([]byte, error) {
+	return store.Client.Get(key).Bytes()
+}
+
+// Set saves a new value for key
+func (store *RedisStore) Set(key string, contents []byte) error {
+	return store.Client.Set(key, contents, 0).Err()
+}
+
+// Delete removes a key from the store
+func (store *RedisStore) Delete(key string) error {
+	return store.Client.Del(key).Err()
+}

--- a/pkg/cache/store.go
+++ b/pkg/cache/store.go
@@ -3,8 +3,8 @@ package cache
 type (
 	// Store is a generic interface for cache stores
 	Store interface {
-		Get(key string) (interface{}, error)
-		Set(key string, contents interface{}) error
+		Get(key string) ([]byte, error)
+		Set(key string, contents []byte) error
 		Delete(key string) error
 	}
 )

--- a/pkg/cache/store_test.go
+++ b/pkg/cache/store_test.go
@@ -2,6 +2,7 @@ package cache
 
 import (
 	"fmt"
+	"os"
 	"testing"
 
 	"github.com/stretchr/testify/suite"
@@ -14,25 +15,33 @@ type StoreTestSuite struct {
 
 func (suite *StoreTestSuite) SetupSuite() {
 	suite.Stores = make(map[string]Store)
+
 	inMemoryStore := NewInMemoryStore()
 	suite.Stores["InMemory"] = inMemoryStore
+
+	if os.Getenv("TEST_REDIS") == "1" {
+		redisStore := NewRedisStore(&RedisStoreOptions{
+			Addr: "localhost:6379",
+		})
+		suite.Stores["Redis"] = redisStore
+	}
 }
 
 func (suite *StoreTestSuite) TestAllStores() {
 	for key, store := range suite.Stores {
-		err := store.Set("x", 1)
+		err := store.Set("x", []byte("1"))
 		suite.Nil(err, fmt.Sprintf("able to create a new key using %s store", key))
 
 		value, err := store.Get("x")
 		suite.Nil(err, "able to get a key")
-		suite.Equal(1, value, fmt.Sprintf("able to get a key using %s store", key))
+		suite.Equal([]byte("1"), value, fmt.Sprintf("able to get a key using %s store", key))
 
-		err = store.Set("x", 2)
+		err = store.Set("x", []byte("2"))
 		suite.Nil(err, fmt.Sprintf("able to update an existing key using %s store", key))
 
 		value, err = store.Get("x")
 		suite.Nil(err, fmt.Sprintf("able to get a key after update using %s store", key))
-		suite.Equal(2, value, fmt.Sprintf("able to get a key after update using %s store", key))
+		suite.Equal([]byte("2"), value, fmt.Sprintf("able to get a key after update using %s store", key))
 
 		err = store.Delete("x")
 		suite.Nil(err, fmt.Sprintf("able to delete a key using %s store", key))
@@ -41,8 +50,11 @@ func (suite *StoreTestSuite) TestAllStores() {
 		suite.NotNil(err, fmt.Sprintf("error getting deleted key using %s store", key))
 		suite.Nil(value, fmt.Sprintf("error getting deleted key using %s store", key))
 
-		err = store.Delete("x")
-		suite.NotNil(err, fmt.Sprintf("error deleting already-deleted key using %s store", key))
+		// in Redis, "A key is ignored if it does not exist"
+		if key == "InMemory" {
+			err = store.Delete("x")
+			suite.NotNil(err, fmt.Sprintf("error deleting already-deleted key using %s store", key))
+		}
 	}
 }
 

--- a/pkg/cache/store_test.go
+++ b/pkg/cache/store_test.go
@@ -50,11 +50,8 @@ func (suite *StoreTestSuite) TestAllStores() {
 		suite.NotNil(err, fmt.Sprintf("error getting deleted key using %s store", key))
 		suite.Nil(value, fmt.Sprintf("error getting deleted key using %s store", key))
 
-		// in Redis, "A key is ignored if it does not exist"
-		if key == "InMemory" {
-			err = store.Delete("x")
-			suite.NotNil(err, fmt.Sprintf("error deleting already-deleted key using %s store", key))
-		}
+		err = store.Delete("x")
+		suite.Nil(err, fmt.Sprintf("no error deleting already-deleted key using %s store", key))
 	}
 }
 

--- a/pkg/chartmuseum/router/middleware.go
+++ b/pkg/chartmuseum/router/middleware.go
@@ -15,11 +15,21 @@ import (
 
 // this is needed due to issues with Gin handling wildcard routes:
 // https://github.com/gin-gonic/gin/issues/388
-func prefixPathMiddleware(engine *gin.Engine, pathPrefix string) gin.HandlerFunc {
+// also adds the "ChartMuseum-Repo" when appropriate
+func prefixPathMiddleware(engine *gin.Engine, pathPrefix string, depth int) gin.HandlerFunc {
 	return func(c *gin.Context) {
 		reqPath := c.Request.URL.Path
 		if strings.HasPrefix(reqPath, pathPrefix) {
 			return
+		}
+		pathSplit := strings.Split(reqPath, "/")
+		if len(pathSplit) > depth {
+			var a []string
+			for i := 1; i <= depth; i++ {
+				a = append(a, pathSplit[i])
+			}
+			cmRepoHeader := strings.Join(a, "/")
+			c.Request.Header.Add("ChartMuseum-Repo", cmRepoHeader)
 		}
 		c.Request.URL.Path = pathutil.Join(pathPrefix, reqPath)
 		engine.HandleContext(c)

--- a/pkg/chartmuseum/router/router.go
+++ b/pkg/chartmuseum/router/router.go
@@ -33,6 +33,7 @@ type (
 		PathPrefix    string
 		EnableMetrics bool
 		AnonymousGet  bool
+		Depth         int
 	}
 )
 
@@ -43,7 +44,7 @@ func NewRouter(options RouterOptions) *Router {
 
 	// Middleware
 	engine.Use(location.Default(), ginrequestid.RequestId(), loggingMiddleware(options.Logger, options.PathPrefix),
-		gin.Recovery(), prefixPathMiddleware(engine, options.PathPrefix))
+		gin.Recovery(), prefixPathMiddleware(engine, options.PathPrefix, options.Depth))
 
 	if options.EnableMetrics {
 		p := ginprometheus.NewPrometheus("chartmuseum")

--- a/pkg/chartmuseum/server.go
+++ b/pkg/chartmuseum/server.go
@@ -31,6 +31,7 @@ type (
 		AnonymousGet           bool
 		GenIndex               bool
 		IndexLimit             int
+		Depth                  int
 	}
 
 	Server interface {
@@ -57,6 +58,7 @@ func NewServer(options ServerOptions) (Server, error) {
 		TlsKey:        options.TlsKey,
 		EnableMetrics: options.EnableMetrics,
 		AnonymousGet:  options.AnonymousGet,
+		Depth:         options.Depth,
 	}
 	if options.EnableMultiTenancy {
 		routerOptions.PathPrefix = mt.PathPrefix
@@ -73,6 +75,7 @@ func NewServer(options ServerOptions) (Server, error) {
 			Router:         router,
 			StorageBackend: options.StorageBackend,
 			Cache:          options.Cache,
+			Depth:          options.Depth,
 		})
 	} else {
 		server, err = st.NewSingleTenantServer(st.SingleTenantServerOptions{

--- a/pkg/chartmuseum/server/multitenant/handlers.go
+++ b/pkg/chartmuseum/server/multitenant/handlers.go
@@ -1,11 +1,6 @@
 package multitenant
 
 import (
-	"fmt"
-	"strings"
-
-	"github.com/kubernetes-helm/chartmuseum/pkg/repo"
-
 	"github.com/gin-gonic/gin"
 )
 
@@ -37,23 +32,19 @@ func (server *MultiTenantServer) defaultHandler(c *gin.Context) {
 }
 
 func (server *MultiTenantServer) getIndexFileRequestHandler(c *gin.Context) {
-	orgName := c.Param("org")
-	repoName := c.Param("repo")
-	prefix := fmt.Sprintf("%s/%s", orgName, repoName)
-	indexFile, err := server.getIndexFile(prefix)
+	repo := server.getContextParam(c, "repo")
+	indexFile, err := server.getIndexFile(repo)
 	if err != nil {
 		c.JSON(err.Status, gin.H{"error": err.Message})
 		return
 	}
-	c.Data(200, repo.IndexFileContentType, indexFile.Raw)
+	c.Data(200, indexFileContentType, indexFile.Raw)
 }
 
 func (server *MultiTenantServer) getStorageObjectRequestHandler(c *gin.Context) {
-	orgName := c.Param("org")
-	repoName := c.Param("repo")
-	prefix := fmt.Sprintf("%s/%s", orgName, repoName)
-	filename := c.Param("filename")
-	storageObject, err := server.getStorageObject(prefix, filename)
+	repo := server.getContextParam(c, "repo")
+	filename := server.getContextParam(c, "filename")
+	storageObject, err := server.getStorageObject(repo, filename)
 	if err != nil {
 		c.JSON(err.Status, gin.H{"error": err.Message})
 		return

--- a/pkg/chartmuseum/server/multitenant/handlers.go
+++ b/pkg/chartmuseum/server/multitenant/handlers.go
@@ -25,6 +25,13 @@ var (
 	`)
 )
 
+type (
+	HTTPError struct {
+		Status  int
+		Message string
+	}
+)
+
 func (server *MultiTenantServer) defaultHandler(c *gin.Context) {
 	c.Data(200, "text/html", warningHTML)
 }
@@ -33,56 +40,23 @@ func (server *MultiTenantServer) getIndexFileRequestHandler(c *gin.Context) {
 	orgName := c.Param("org")
 	repoName := c.Param("repo")
 	prefix := fmt.Sprintf("%s/%s", orgName, repoName)
-
-	objects, err := server.StorageBackend.ListObjects(prefix)
+	indexFile, err := server.getIndexFile(prefix)
 	if err != nil {
-		c.JSON(500, gin.H{"error": fmt.Sprintf("%s", err)})
+		c.JSON(err.Status, gin.H{"error": err.Message})
 		return
 	}
-
-	index := repo.NewIndex("")
-	for _, object := range objects {
-		op := object.Path
-		objectPath := fmt.Sprintf("%s/%s", prefix, op)
-		object, err = server.StorageBackend.GetObject(objectPath)
-		if err != nil {
-			// TODO handle err
-			continue
-		}
-		chartVersion, err := repo.ChartVersionFromStorageObject(object)
-		if err != nil {
-			// TODO handle err
-			continue
-		}
-		chartVersion.URLs[0] = fmt.Sprintf("charts/%s", op)
-		index.AddEntry(chartVersion)
-	}
-
-	index.Regenerate()
-	c.Data(200, repo.IndexFileContentType, index.Raw)
+	c.Data(200, repo.IndexFileContentType, indexFile.Raw)
 }
 
 func (server *MultiTenantServer) getStorageObjectRequestHandler(c *gin.Context) {
 	orgName := c.Param("org")
 	repoName := c.Param("repo")
 	prefix := fmt.Sprintf("%s/%s", orgName, repoName)
-
 	filename := c.Param("filename")
-	isChartPackage := strings.HasSuffix(filename, repo.ChartPackageFileExtension)
-	isProvenanceFile := strings.HasSuffix(filename, repo.ProvenanceFileExtension)
-	if !isChartPackage && !isProvenanceFile {
-		c.JSON(500, gin.H{"error": "unsupported file extension"})
-		return
-	}
-	objectPath := fmt.Sprintf("%s/%s", prefix, filename)
-	object, err := server.StorageBackend.GetObject(objectPath)
+	storageObject, err := server.getStorageObject(prefix, filename)
 	if err != nil {
-		c.JSON(404, gin.H{"error": "not found"})
+		c.JSON(err.Status, gin.H{"error": err.Message})
 		return
 	}
-	if isProvenanceFile {
-		c.Data(200, repo.ProvenanceFileContentType, object.Content)
-		return
-	}
-	c.Data(200, repo.ChartPackageContentType, object.Content)
+	c.Data(200, storageObject.ContentType, storageObject.Content)
 }

--- a/pkg/chartmuseum/server/multitenant/index.go
+++ b/pkg/chartmuseum/server/multitenant/index.go
@@ -7,6 +7,10 @@ import (
 	"github.com/kubernetes-helm/chartmuseum/pkg/repo"
 )
 
+var (
+	indexFileContentType = "application/x-yaml"
+)
+
 func (server *MultiTenantServer) getIndexFile(prefix string) (*repo.Index, *HTTPError) {
 	objects, err := server.StorageBackend.ListObjects(prefix)
 	if err != nil {
@@ -25,7 +29,7 @@ func (server *MultiTenantServer) getIndexFile(prefix string) (*repo.Index, *HTTP
 		if err != nil {
 			continue
 		}
-		chartVersion.URLs[0] = fmt.Sprintf("charts/%s", op)
+		chartVersion.URLs = []string{fmt.Sprintf("charts/%s", op)}
 		indexFile.AddEntry(chartVersion)
 	}
 

--- a/pkg/chartmuseum/server/multitenant/index.go
+++ b/pkg/chartmuseum/server/multitenant/index.go
@@ -1,0 +1,34 @@
+package multitenant
+
+
+import (
+	"fmt"
+
+	"github.com/kubernetes-helm/chartmuseum/pkg/repo"
+)
+
+func (server *MultiTenantServer) getIndexFile(prefix string) (*repo.Index, *HTTPError) {
+	objects, err := server.StorageBackend.ListObjects(prefix)
+	if err != nil {
+		return new(repo.Index), &HTTPError{500, err.Error()}
+	}
+
+	indexFile := repo.NewIndex("")
+	for _, object := range objects {
+		op := object.Path
+		objectPath := fmt.Sprintf("%s/%s", prefix, op)
+		object, err = server.StorageBackend.GetObject(objectPath)
+		if err != nil {
+			continue
+		}
+		chartVersion, err := repo.ChartVersionFromStorageObject(object)
+		if err != nil {
+			continue
+		}
+		chartVersion.URLs[0] = fmt.Sprintf("charts/%s", op)
+		indexFile.AddEntry(chartVersion)
+	}
+
+	indexFile.Regenerate()
+	return indexFile, nil
+}

--- a/pkg/chartmuseum/server/multitenant/routes.go
+++ b/pkg/chartmuseum/server/multitenant/routes.go
@@ -1,10 +1,10 @@
 package multitenant
 
-func (server *MultiTenantServer) setRoutes() {
+func (s *MultiTenantServer) setRoutes() {
 	// Server Info
-	server.Router.Groups.ReadAccess.GET(p("/"), server.defaultHandler)
+	s.Router.Groups.ReadAccess.GET(s.p("/"), s.defaultHandler)
 
 	// Helm Chart Repository
-	server.Router.Groups.ReadAccess.GET(p("/:org/:repo/index.yaml"), server.getIndexFileRequestHandler)
-	server.Router.Groups.ReadAccess.GET(p("/:org/:repo/charts/:filename"), server.getStorageObjectRequestHandler)
+	s.Router.Groups.ReadAccess.GET(s.p("/:repo/index.yaml"), s.getIndexFileRequestHandler)
+	s.Router.Groups.ReadAccess.GET(s.p("/:repo/charts/:filename"), s.getStorageObjectRequestHandler)
 }

--- a/pkg/chartmuseum/server/multitenant/server_test.go
+++ b/pkg/chartmuseum/server/multitenant/server_test.go
@@ -71,7 +71,7 @@ func (suite *MultiTenantServerTestSuite) populateOrgRepoDirectory(org string, re
 
 	destFileProvfile, err := os.Create(pathutil.Join(newDir, "mychart-0.1.0.tgz.prov"))
 	suite.Nil(err, fmt.Sprintf("no error creating new provenance file in %s", testPrefix))
-	defer destFileTarball.Close()
+	defer destFileProvfile.Close()
 
 	_, err = io.Copy(destFileProvfile, srcFileProvfile)
 	suite.Nil(err, fmt.Sprintf("no error copying test provenance file to %s", testPrefix))
@@ -99,7 +99,9 @@ func (suite *MultiTenantServerTestSuite) SetupSuite() {
 
 	backend := storage.Backend(storage.NewLocalFilesystemBackend(suite.TempDirectory))
 
-	logger, err := cm_logger.NewLogger(cm_logger.LoggerOptions{})
+	logger, err := cm_logger.NewLogger(cm_logger.LoggerOptions{
+		Debug: true,
+	})
 	suite.Nil(err, "no error creating logger")
 
 	router := cm_router.NewRouter(cm_router.RouterOptions{

--- a/pkg/chartmuseum/server/multitenant/storage.go
+++ b/pkg/chartmuseum/server/multitenant/storage.go
@@ -8,6 +8,11 @@ import (
 	"github.com/kubernetes-helm/chartmuseum/pkg/storage"
 )
 
+var (
+	chartPackageContentType = "application/x-tar"
+	provenanceFileContentType = "application/pgp-signature"
+)
+
 type (
 	StorageObject struct {
 		*storage.Object
@@ -31,9 +36,9 @@ func (server *MultiTenantServer) getStorageObject(prefix string, filename string
 
 	var contentType string
 	if isProvenanceFile {
-		contentType = repo.ProvenanceFileContentType
+		contentType = chartPackageContentType
 	} else {
-		contentType = repo.ChartPackageContentType
+		contentType = chartPackageContentType
 	}
 
 	storageObject := &StorageObject{

--- a/pkg/chartmuseum/server/multitenant/storage.go
+++ b/pkg/chartmuseum/server/multitenant/storage.go
@@ -1,0 +1,45 @@
+package multitenant
+
+import (
+	"fmt"
+	"strings"
+
+	"github.com/kubernetes-helm/chartmuseum/pkg/repo"
+	"github.com/kubernetes-helm/chartmuseum/pkg/storage"
+)
+
+type (
+	StorageObject struct {
+		*storage.Object
+		ContentType string
+	}
+)
+
+func (server *MultiTenantServer) getStorageObject(prefix string, filename string) (*StorageObject, *HTTPError) {
+	isChartPackage := strings.HasSuffix(filename, repo.ChartPackageFileExtension)
+	isProvenanceFile := strings.HasSuffix(filename, repo.ProvenanceFileExtension)
+	if !isChartPackage && !isProvenanceFile {
+		return nil, &HTTPError{500, "unsupported file extension"}
+	}
+
+	objectPath := fmt.Sprintf("%s/%s", prefix, filename)
+
+	object, err := server.StorageBackend.GetObject(objectPath)
+	if err != nil {
+		return nil, &HTTPError{404, "object not found"}
+	}
+
+	var contentType string
+	if isProvenanceFile {
+		contentType = repo.ProvenanceFileContentType
+	} else {
+		contentType = repo.ChartPackageContentType
+	}
+
+	storageObject := &StorageObject{
+		Object: &object,
+		ContentType: contentType,
+	}
+
+	return storageObject, nil
+}


### PR DESCRIPTION
Added the ability to specify how many levels of nested storage directories you want for multitenancy, fixes #76.

Before this, we were mandating `/<org>/<repo>` for URL structure (and directory layout). This change will enable those who wish to have just `/<repo>`, or even deeper nesting, such as `/<org>/<team>/<repo>`.

Stuff that is also included here:
- Separated web handlers from index and storage processing, fixes #75
- Redis implementation of Cache interface. Currently unused, but will help for #72

An overview of the `--depth` option usage is below. Note that this must be used in combination with the `--multitenant` flag to get this functionality.

## `--depth=0` (default)
Given the following directory structure
```
charts
├── chartmuseum-0.4.0.tgz
├── nginx-ingress-0.9.3.tgz
```
and starting ChartMuseum with
```
chartmuseum --multitenant --depth=0 --storage=local --storage-local-rootdir=./charts 
```
will give you
```
http://localhost:8080/index.yaml
```

(`--depth=0` will essentially replace need the for a separate singletenant server)

## `--depth=1`
Given the following directory structure
```
charts
├── repo1
│   ├── nginx-ingress-0.9.3.tgz
├── repo2
│   ├── chartmuseum-0.4.0.tgz
```
and starting ChartMuseum with
```
chartmuseum --multitenant --depth=1 --storage=local --storage-local-rootdir=./charts 
```
will give you
```
http://localhost:8080/repo1/index.yaml
http://localhost:8080/repo2/index.yaml
```

## `--depth=2`
Given the following directory structure
```
charts
├── org1
│   ├── repo1
│   │   └── nginx-ingress-0.9.3.tgz
├── org2
│   ├── repo1
│   │   └── chartmuseum-0.4.0.tgz
```
and starting ChartMuseum with
```
chartmuseum --multitenant --depth=2 --storage=local --storage-local-rootdir=./charts 
```
will give you
```
http://localhost:8080/org1/repo1/index.yaml
http://localhost:8080/org2/repo1/index.yaml
```

## `--depth=3`
Given the following directory structure
```
charts
├── org1
│   ├── team1
│   |    ├── repo1
│   │    |    └── nginx-ingress-0.9.3.tgz
├── org2
│   ├── team1
│   |    ├── repo1
│   │    |    └── chartmuseum-0.4.0.tgz
```
and starting ChartMuseum with
```
chartmuseum --multitenant --depth=3 --storage=local --storage-local-rootdir=./charts 
```
will give you
```
http://localhost:8080/org1/team1/repo1/index.yaml
http://localhost:8080/org2/team1/repo1/index.yaml
```

## `--depth=?`
In theory, any level above 3 should work, but I have not tested it. If this becomes an issue, we can put a max on it later.