### PR TITLE
switch to path.Join to avoid leading slash

### DIFF
--- a/pkg/chartmuseum/server/multitenant/cache.go
+++ b/pkg/chartmuseum/server/multitenant/cache.go
@@ -19,7 +19,7 @@ _.-'  \        ( \___
 import (
 	"context"
 	"errors"
-	"fmt"
+	pathutil "path"
 	"sync"
 
 	cm_logger "github.com/kubernetes-helm/chartmuseum/pkg/chartmuseum/logger"
@@ -275,7 +275,7 @@ func (server *MultiTenantServer) getObjectChartVersion(repo string, object cm_st
 	op := object.Path
 	if load {
 		var err error
-		objectPath := fmt.Sprintf("%s/%s", repo, op)
+		objectPath := pathutil.Join(repo, op)
 		object, err = server.StorageBackend.GetObject(objectPath)
 		if err != nil {
 			return nil, err

--- a/pkg/chartmuseum/server/multitenant/storage.go
+++ b/pkg/chartmuseum/server/multitenant/storage.go
@@ -1,7 +1,7 @@
 package multitenant
 
 import (
-	"fmt"
+	pathutil "path"
 	"strings"
 
 	cm_logger "github.com/kubernetes-helm/chartmuseum/pkg/chartmuseum/logger"
@@ -32,7 +32,7 @@ func (server *MultiTenantServer) getStorageObject(log cm_logger.LoggingFn, repo 
 		return nil, &HTTPError{500, "unsupported file extension"}
 	}
 
-	objectPath := fmt.Sprintf("%s/%s", repo, filename)
+	objectPath := pathutil.Join(repo, filename)
 
 	object, err := server.StorageBackend.GetObject(objectPath)
 	if err != nil {


### PR DESCRIPTION
Fixes #96 

Azure does not like the leading slash in object path "/mychart-0.1.0.tgz", needs it to be just "mychart-0.1.0.tgz"