### PR TITLE
Ability to specify config via yaml file

### DIFF
--- a/Gopkg.lock
+++ b/Gopkg.lock
@@ -103,6 +103,12 @@
   version = "v3.1.0"
 
 [[projects]]
+  name = "github.com/fsnotify/fsnotify"
+  packages = ["."]
+  revision = "c2828203cd70a50dcccfb2761f8b1f8ceef9a8e9"
+  version = "v1.4.7"
+
+[[projects]]
   name = "github.com/ghodss/yaml"
   packages = ["."]
   revision = "73d445a93680fa1a78ae23a5839bad48f32ba1ee"
@@ -162,9 +168,32 @@
   revision = "2cadd475a3e966ec9b77a21afc530dbacec6d613"
 
 [[projects]]
+  branch = "master"
+  name = "github.com/hashicorp/hcl"
+  packages = [
+    ".",
+    "hcl/ast",
+    "hcl/parser",
+    "hcl/printer",
+    "hcl/scanner",
+    "hcl/strconv",
+    "hcl/token",
+    "json/parser",
+    "json/scanner",
+    "json/token"
+  ]
+  revision = "ef8a98b0bbce4a65b5aa4c368430a80ddc533168"
+
+[[projects]]
   name = "github.com/jmespath/go-jmespath"
   packages = ["."]
   revision = "bd40a432e4c76585ef6b72d3fd96fb9b6dc7b68d"
+
+[[projects]]
+  name = "github.com/magiconair/properties"
+  packages = ["."]
+  revision = "c3beff4c2358b44d0493c7dda585e7db7ff28ae6"
+  version = "v1.7.6"
 
 [[projects]]
   name = "github.com/marstr/guid"
@@ -182,6 +211,18 @@
   name = "github.com/matttproud/golang_protobuf_extensions"
   packages = ["pbutil"]
   revision = "fc2b8d3a73c4867e51861bbdd5ae3c1f0869dd6a"
+
+[[projects]]
+  branch = "master"
+  name = "github.com/mitchellh/mapstructure"
+  packages = ["."]
+  revision = "00c29f56e2386353d58c599509e8dc3801b0d716"
+
+[[projects]]
+  name = "github.com/pelletier/go-toml"
+  packages = ["."]
+  revision = "acdc4509485b587f5e675510c4f2c63e90ff68a8"
+  version = "v1.1.0"
 
 [[projects]]
   name = "github.com/pmezard/go-difflib"
@@ -231,9 +272,36 @@
   revision = "89742aefa4b206dcf400792f3bd35b542998eb3b"
 
 [[projects]]
+  name = "github.com/spf13/afero"
+  packages = [
+    ".",
+    "mem"
+  ]
+  revision = "63644898a8da0bc22138abf860edaf5277b6102e"
+  version = "v1.1.0"
+
+[[projects]]
+  name = "github.com/spf13/cast"
+  packages = ["."]
+  revision = "8965335b8c7107321228e3e3702cab9832751bac"
+  version = "v1.2.0"
+
+[[projects]]
+  branch = "master"
+  name = "github.com/spf13/jwalterweatherman"
+  packages = ["."]
+  revision = "7c0cea34c8ece3fbeb2b27ab9b59511d360fb394"
+
+[[projects]]
   name = "github.com/spf13/pflag"
   packages = ["."]
   revision = "9ff6c6923cfffbcd502984b8e0c80539a94968b7"
+
+[[projects]]
+  name = "github.com/spf13/viper"
+  packages = ["."]
+  revision = "b5e8006cbee93ec955a89ab31e0e3ce3204f3736"
+  version = "v1.0.2"
 
 [[projects]]
   name = "github.com/stretchr/testify"
@@ -459,6 +527,6 @@
 [solve-meta]
   analyzer-name = "dep"
   analyzer-version = 1
-  inputs-digest = "e58df2b608c972803e8f342e24c7e5f505a165832db2f0d53af890adbe2581db"
+  inputs-digest = "e3aad15b95dd121c85e6d2750069d14083975ccdb2b70012e02c0138c9ac0576"
   solver-name = "gps-cdcl"
   solver-version = 1

--- a/Gopkg.toml
+++ b/Gopkg.toml
@@ -29,6 +29,10 @@
   version = "1.20.0"
 
 [[constraint]]
+  name = "github.com/spf13/viper"
+  version = "1.0.2"
+
+[[constraint]]
   name = "go.uber.org/zap"
   version = "1.5.0"
 

--- a/cmd/chartmuseum/main.go
+++ b/cmd/chartmuseum/main.go
@@ -7,6 +7,7 @@ import (
 	"strings"
 
 	"github.com/kubernetes-helm/chartmuseum/pkg/chartmuseum"
+	"github.com/kubernetes-helm/chartmuseum/pkg/config"
 	"github.com/kubernetes-helm/chartmuseum/pkg/storage"
 
 	"github.com/urfave/cli"
@@ -30,32 +31,38 @@ func main() {
 	app.Version = fmt.Sprintf("%s (build %s)", Version, Revision)
 	app.Usage = "Helm Chart Repository with support for Amazon S3 and Google Cloud Storage"
 	app.Action = cliHandler
-	app.Flags = cliFlags
+	app.Flags = config.CLIFlags
 	app.Run(os.Args)
 }
 
 func cliHandler(c *cli.Context) {
-	backend := backendFromContext(c)
+	conf := config.NewConfig()
+	err := conf.UpdateFromCLIContext(c)
+	if err != nil {
+		crash(err)
+	}
+
+	backend := backendFromConfig(conf)
 
 	options := chartmuseum.ServerOptions{
 		StorageBackend:         backend,
-		ChartURL:               c.String("chart-url"),
-		TlsCert:                c.String("tls-cert"),
-		TlsKey:                 c.String("tls-key"),
-		Username:               c.String("basic-auth-user"),
-		Password:               c.String("basic-auth-pass"),
-		ChartPostFormFieldName: c.String("chart-post-form-field-name"),
-		ProvPostFormFieldName:  c.String("prov-post-form-field-name"),
-		ContextPath:            c.String("context-path"),
-		LogJSON:                c.Bool("log-json"),
-		Debug:                  c.Bool("debug"),
-		EnableAPI:              !c.Bool("disable-api"),
-		AllowOverwrite:         c.Bool("allow-overwrite"),
-		EnableMetrics:          !c.Bool("disable-metrics"),
-		AnonymousGet:           c.Bool("auth-anonymous-get"),
-		GenIndex:               c.Bool("gen-index"),
-		IndexLimit:             c.Int("index-limit"),
-		Depth:                  c.Int("depth"),
+		ChartURL:               conf.GetString("charturl"),
+		TlsCert:                conf.GetString("tls.cert"),
+		TlsKey:                 conf.GetString("tls.key"),
+		Username:               conf.GetString("basicauth.user"),
+		Password:               conf.GetString("basicauth.pass"),
+		ChartPostFormFieldName: conf.GetString("chartpostformfieldname"),
+		ProvPostFormFieldName:  conf.GetString("provpostformfieldname"),
+		ContextPath:            conf.GetString("contextpath"),
+		LogJSON:                conf.GetBool("logjson"),
+		Debug:                  conf.GetBool("debug"),
+		EnableAPI:              !conf.GetBool("disableapi"),
+		AllowOverwrite:         conf.GetBool("allowoverwrite"),
+		EnableMetrics:          !conf.GetBool("disablemetrics"),
+		AnonymousGet:           conf.GetBool("authanonymousget"),
+		GenIndex:               conf.GetBool("genindex"),
+		IndexLimit:             conf.GetInt("indexlimit"),
+		Depth:                  conf.GetInt("depth"),
 	}
 
 	server, err := newServer(options)
@@ -63,26 +70,26 @@ func cliHandler(c *cli.Context) {
 		crash(err)
 	}
 
-	server.Listen(c.Int("port"))
+	server.Listen(conf.GetInt("port"))
 }
 
-func backendFromContext(c *cli.Context) storage.Backend {
-	crashIfContextMissingFlags(c, []string{"storage"})
+func backendFromConfig(conf *config.Config) storage.Backend {
+	crashIfConfigMissingVars(conf, []string{"storage.backend"})
 
 	var backend storage.Backend
 
-	storageFlag := strings.ToLower(c.String("storage"))
+	storageFlag := strings.ToLower(conf.GetString("storage.backend"))
 	switch storageFlag {
 	case "local":
-		backend = localBackendFromContext(c)
+		backend = localBackendFromConfig(conf)
 	case "amazon":
-		backend = amazonBackendFromContext(c)
+		backend = amazonBackendFromConfig(conf)
 	case "google":
-		backend = googleBackendFromContext(c)
+		backend = googleBackendFromConfig(conf)
 	case "microsoft":
-		backend = microsoftBackendFromContext(c)
+		backend = microsoftBackendFromConfig(conf)
 	case "alibaba":
-		backend = alibabaBackendFromContext(c)
+		backend = alibabaBackendFromConfig(conf)
 	default:
 		crash("Unsupported storage backend: ", storageFlag)
 	}
@@ -90,236 +97,63 @@ func backendFromContext(c *cli.Context) storage.Backend {
 	return backend
 }
 
-func localBackendFromContext(c *cli.Context) storage.Backend {
-	crashIfContextMissingFlags(c, []string{"storage-local-rootdir"})
+func localBackendFromConfig(conf *config.Config) storage.Backend {
+	crashIfConfigMissingVars(conf, []string{"storage.local.rootdir"})
 	return storage.Backend(storage.NewLocalFilesystemBackend(
-		c.String("storage-local-rootdir"),
+		conf.GetString("storage.local.rootdir"),
 	))
 }
 
-func amazonBackendFromContext(c *cli.Context) storage.Backend {
+func amazonBackendFromConfig(conf *config.Config) storage.Backend {
 	// If using alternative s3 endpoint (e.g. Minio) default region to us-east-1
-	if c.String("storage-amazon-endpoint") != "" && c.String("storage-amazon-region") == "" {
-		c.Set("storage-amazon-region", "us-east-1")
+	if conf.GetString("storage.amazon.endpoint") != "" && conf.GetString("storage.amazon.region") == "" {
+		conf.Set("storage.amazon.region", "us-east-1")
 	}
-	crashIfContextMissingFlags(c, []string{"storage-amazon-bucket", "storage-amazon-region"})
+	crashIfConfigMissingVars(conf, []string{"storage.amazon.bucket", "storage.amazon.region"})
 	return storage.Backend(storage.NewAmazonS3Backend(
-		c.String("storage-amazon-bucket"),
-		c.String("storage-amazon-prefix"),
-		c.String("storage-amazon-region"),
-		c.String("storage-amazon-endpoint"),
-		c.String("storage-amazon-sse"),
+		conf.GetString("storage.amazon.bucket"),
+		conf.GetString("storage.amazon.prefix"),
+		conf.GetString("storage.amazon.region"),
+		conf.GetString("storage.amazon.endpoint"),
+		conf.GetString("storage.amazon.sse"),
 	))
 }
 
-func googleBackendFromContext(c *cli.Context) storage.Backend {
-	crashIfContextMissingFlags(c, []string{"storage-google-bucket"})
+func googleBackendFromConfig(conf *config.Config) storage.Backend {
+	crashIfConfigMissingVars(conf, []string{"storage.google.bucket"})
 	return storage.Backend(storage.NewGoogleCSBackend(
-		c.String("storage-google-bucket"),
-		c.String("storage-google-prefix"),
+		conf.GetString("storage.google.bucket"),
+		conf.GetString("storage.google.prefix"),
 	))
 }
 
-func microsoftBackendFromContext(c *cli.Context) storage.Backend {
-	crashIfContextMissingFlags(c, []string{"storage-microsoft-container"})
+func microsoftBackendFromConfig(conf *config.Config) storage.Backend {
+	crashIfConfigMissingVars(conf, []string{"storage.microsoft.container"})
 	return storage.Backend(storage.NewMicrosoftBlobBackend(
-		c.String("storage-microsoft-container"),
-		c.String("storage-microsoft-prefix"),
+		conf.GetString("storage.microsoft.container"),
+		conf.GetString("storage.microsoft.prefix"),
 	))
 }
 
-func alibabaBackendFromContext(c *cli.Context) storage.Backend {
-	crashIfContextMissingFlags(c, []string{"storage-alibaba-bucket"})
+func alibabaBackendFromConfig(conf *config.Config) storage.Backend {
+	crashIfConfigMissingVars(conf, []string{"storage.alibaba.bucket"})
 	return storage.Backend(storage.NewAlibabaCloudOSSBackend(
-		c.String("storage-alibaba-bucket"),
-		c.String("storage-alibaba-prefix"),
-		c.String("storage-alibaba-endpoint"),
-		c.String("storage-alibaba-sse"),
+		conf.GetString("storage.alibaba.bucket"),
+		conf.GetString("storage.alibaba.prefix"),
+		conf.GetString("storage.alibaba.endpoint"),
+		conf.GetString("storage.alibaba.sse"),
 	))
 }
 
-func crashIfContextMissingFlags(c *cli.Context, flags []string) {
+func crashIfConfigMissingVars(conf *config.Config, vars []string) {
 	missing := []string{}
-	for _, flag := range flags {
-		if c.String(flag) == "" {
+	for _, v := range vars {
+		if conf.GetString(v) == "" {
+			flag := config.GetCLIFlagFromVarName(v)
 			missing = append(missing, fmt.Sprintf("--%s", flag))
 		}
 	}
 	if len(missing) > 0 {
 		crash("Missing required flags(s): ", strings.Join(missing, ", "))
 	}
-}
-
-var cliFlags = []cli.Flag{
-	cli.BoolFlag{
-		Name:   "gen-index",
-		Usage:  "generate index.yaml, print to stdout and exit",
-		EnvVar: "GEN_INDEX",
-	},
-	cli.BoolFlag{
-		Name:   "debug",
-		Usage:  "show debug messages",
-		EnvVar: "DEBUG",
-	},
-	cli.BoolFlag{
-		Name:   "log-json",
-		Usage:  "output structured logs as json",
-		EnvVar: "LOG_JSON",
-	},
-	cli.BoolFlag{
-		Name:   "disable-metrics",
-		Usage:  "disable Prometheus metrics",
-		EnvVar: "DISABLE_METRICS",
-	},
-	cli.BoolFlag{
-		Name:   "disable-api",
-		Usage:  "disable all routes prefixed with /api",
-		EnvVar: "DISABLE_API",
-	},
-	cli.BoolFlag{
-		Name:   "allow-overwrite",
-		Usage:  "allow chart versions to be re-uploaded",
-		EnvVar: "ALLOW_OVERWRITE",
-	},
-	cli.IntFlag{
-		Name:   "port",
-		Value:  8080,
-		Usage:  "port to listen on",
-		EnvVar: "PORT",
-	},
-	cli.StringFlag{
-		Name:   "chart-url",
-		Usage:  "absolute url for .tgzs in index.yaml",
-		EnvVar: "CHART_URL",
-	},
-	cli.StringFlag{
-		Name:   "basic-auth-user",
-		Usage:  "username for basic http authentication",
-		EnvVar: "BASIC_AUTH_USER",
-	},
-	cli.StringFlag{
-		Name:   "basic-auth-pass",
-		Usage:  "password for basic http authentication",
-		EnvVar: "BASIC_AUTH_PASS",
-	},
-	cli.BoolFlag{
-		Name:   "auth-anonymous-get",
-		Usage:  "allow anonymous GET operations when auth is used",
-		EnvVar: "AUTH_ANONYMOUS_GET",
-	},
-	cli.StringFlag{
-		Name:   "tls-cert",
-		Usage:  "path to tls certificate chain file",
-		EnvVar: "TLS_CERT",
-	},
-	cli.StringFlag{
-		Name:   "tls-key",
-		Usage:  "path to tls key file",
-		EnvVar: "TLS_KEY",
-	},
-	cli.StringFlag{
-		Name:   "storage",
-		Usage:  "storage backend, can be one of: local, amazon, google",
-		EnvVar: "STORAGE",
-	},
-	cli.StringFlag{
-		Name:   "storage-local-rootdir",
-		Usage:  "directory to store charts for local storage backend",
-		EnvVar: "STORAGE_LOCAL_ROOTDIR",
-	},
-	cli.StringFlag{
-		Name:   "storage-amazon-bucket",
-		Usage:  "s3 bucket to store charts for amazon storage backend",
-		EnvVar: "STORAGE_AMAZON_BUCKET",
-	},
-	cli.StringFlag{
-		Name:   "storage-amazon-prefix",
-		Usage:  "prefix to store charts for --storage-amazon-bucket",
-		EnvVar: "STORAGE_AMAZON_PREFIX",
-	},
-	cli.StringFlag{
-		Name:   "storage-amazon-region",
-		Usage:  "region of --storage-amazon-bucket",
-		EnvVar: "STORAGE_AMAZON_REGION",
-	},
-	cli.StringFlag{
-		Name:   "storage-amazon-endpoint",
-		Usage:  "alternative s3 endpoint",
-		EnvVar: "STORAGE_AMAZON_ENDPOINT",
-	},
-	cli.StringFlag{
-		Name:   "storage-amazon-sse",
-		Usage:  "server side encryption algorithm",
-		EnvVar: "STORAGE_AMAZON_SSE",
-	},
-	cli.StringFlag{
-		Name:   "storage-google-bucket",
-		Usage:  "gcs bucket to store charts for google storage backend",
-		EnvVar: "STORAGE_GOOGLE_BUCKET",
-	},
-	cli.StringFlag{
-		Name:   "storage-google-prefix",
-		Usage:  "prefix to store charts for --storage-google-bucket",
-		EnvVar: "STORAGE_GOOGLE_PREFIX",
-	},
-	cli.StringFlag{
-		Name:   "storage-microsoft-container",
-		Usage:  "container to store charts for microsoft storage backend",
-		EnvVar: "STORAGE_MICROSOFT_CONTAINER",
-	},
-	cli.StringFlag{
-		Name:   "storage-microsoft-prefix",
-		Usage:  "prefix to store charts for --storage-microsoft-prefix",
-		EnvVar: "STORAGE_MICROSOFT_PREFIX",
-	},
-	cli.StringFlag{
-		Name:   "storage-alibaba-bucket",
-		Usage:  "OSS bucket to store charts for Alibaba Cloud storage backend",
-		EnvVar: "STORAGE_ALIBABA_BUCKET",
-	},
-	cli.StringFlag{
-		Name:   "storage-alibaba-prefix",
-		Usage:  "prefix to store charts for --storage-alibaba-cloud-bucket",
-		EnvVar: "STORAGE_ALIBABA_PREFIX",
-	},
-	cli.StringFlag{
-		Name:   "storage-alibaba-endpoint",
-		Usage:  "OSS endpoint",
-		EnvVar: "STORAGE_ALIBABA_ENDPOINT",
-	},
-	cli.StringFlag{
-		Name:   "storage-alibaba-sse",
-		Usage:  "server side encryption algorithm for Alibaba Cloud storage backend, AES256 or KMS",
-		EnvVar: "STORAGE_ALIBABA_SSE",
-	},
-	cli.StringFlag{
-		Name:   "chart-post-form-field-name",
-		Value:  "chart",
-		Usage:  "form field which will be queried for the chart file content",
-		EnvVar: "CHART_POST_FORM_FIELD_NAME",
-	},
-	cli.StringFlag{
-		Name:   "prov-post-form-field-name",
-		Value:  "prov",
-		Usage:  "form field which will be queried for the provenance file content",
-		EnvVar: "PROV_POST_FORM_FIELD_NAME",
-	},
-	cli.IntFlag{
-		Name:   "index-limit",
-		Value:  0,
-		Usage:  "parallel scan limit for the repo indexer",
-		EnvVar: "INDEX_LIMIT",
-	},
-	cli.StringFlag{
-		Name:   "context-path",
-		Value:  "",
-		Usage:  "base context path",
-		EnvVar: "CONTEXT_PATH",
-	},
-	cli.IntFlag{
-		Name:   "depth",
-		Value:  0,
-		Usage:  "levels of nested repos for multitenancy",
-		EnvVar: "DEPTH",
-	},
 }

--- a/cmd/chartmuseum/main_test.go
+++ b/cmd/chartmuseum/main_test.go
@@ -27,6 +27,10 @@ func (suite *MainTestSuite) SetupSuite() {
 }
 
 func (suite *MainTestSuite) TestMain() {
+	os.Args = []string{"chartmuseum", "--config", "blahblahblah.yaml"}
+	suite.Panics(main, "bad config")
+	suite.Equal("config file \"blahblahblah.yaml\" does not exist", suite.LastCrashMessage, "crashes with bad config")
+
 	os.Args = []string{"chartmuseum"}
 	suite.Panics(main, "no storage")
 	suite.Equal("Missing required flags(s): --storage", suite.LastCrashMessage, "crashes with no storage")

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -1,0 +1,92 @@
+package config
+
+import (
+	"errors"
+	"fmt"
+	"os"
+	"path/filepath"
+	"strings"
+
+	"github.com/spf13/viper"
+	"github.com/urfave/cli"
+)
+
+type (
+	// Config is a complete set of app configuration
+	Config struct {
+		*viper.Viper
+	}
+)
+
+// NewConfig create a new Config instance
+func NewConfig() *Config {
+	conf := &Config{
+		Viper: viper.New(),
+	}
+	conf.SetConfigType("yaml")
+	conf.setDefaults()
+	return conf
+}
+
+// GetCLIFlagFromVarName returns the name of the CLI flag associated with a config var
+func GetCLIFlagFromVarName(name string) string {
+	var val string
+	if configVar, ok := configVars[name]; ok {
+		if flag := configVar.CLIFlag; flag != nil {
+			val = flag.GetName()
+		}
+	}
+	return val
+}
+
+// UpdateFromCLIContext updates a config based on flags set in CLI context
+func (conf *Config) UpdateFromCLIContext(c *cli.Context) error {
+	err := conf.readConfigFileFromCLIContext(c)
+	if err != nil {
+		return err
+	}
+
+	for key, configVar := range configVars {
+		if flag := configVar.CLIFlag; flag != nil {
+			if name := flag.GetName(); c.IsSet(name) {
+				switch configVar.Type {
+				case stringType:
+					conf.Set(key, c.String(name))
+				case intType:
+					conf.Set(key, c.Int(name))
+				case boolType:
+					conf.Set(key, c.Bool(name))
+				}
+			}
+		}
+	}
+
+	return nil
+}
+
+func (conf *Config) readConfigFileFromCLIContext(c *cli.Context) error {
+	if confFilePath := c.String("config"); confFilePath != "" {
+		if _, err := os.Stat(confFilePath); os.IsNotExist(err) {
+			return errors.New(fmt.Sprintf("config file \"%s\" does not exist", confFilePath))
+		}
+
+		ext := filepath.Ext(confFilePath)
+		if ext != ".yaml" && ext != ".yml" && ext != "" {
+			return errors.New("config file must have .yaml/.yml extension (or no extension)")
+		}
+
+		base := strings.TrimSuffix(filepath.Base(confFilePath), ext)
+		dir := filepath.Dir(confFilePath)
+		conf.SetConfigName(base)
+		conf.AddConfigPath(dir)
+		return conf.ReadInConfig()
+	}
+
+	return nil
+}
+
+func (conf *Config) setDefaults() {
+	for key, configVar := range configVars {
+		conf.SetDefault(key, configVar.Default)
+	}
+}

--- a/pkg/config/config_test.go
+++ b/pkg/config/config_test.go
@@ -1,0 +1,131 @@
+package config
+
+import (
+	"fmt"
+	"io/ioutil"
+	"os"
+	pathutil "path"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/suite"
+	"github.com/urfave/cli"
+)
+
+type ConfigTestSuite struct {
+	suite.Suite
+	TempDirectory  string
+	TempConfigFile string
+}
+
+func (suite *ConfigTestSuite) SetupSuite() {
+	timestamp := time.Now().Format("20060102150405")
+	tempDirectory := fmt.Sprintf("../../.test/chartmuseum-config/%s", timestamp)
+	os.MkdirAll(tempDirectory, os.ModePerm)
+	suite.TempDirectory = tempDirectory
+
+	tempConfigFile := pathutil.Join(tempDirectory, "chartmuseum.yaml")
+
+	data := []byte(
+		`
+basicauth:
+    user: "myuser"
+    pass: "mypass"
+`,
+	)
+
+	err := ioutil.WriteFile(tempConfigFile, data, 0644)
+	suite.Nil(err, fmt.Sprintf("no error creating new config file %s", tempConfigFile))
+	suite.TempConfigFile = tempConfigFile
+}
+
+func (suite *ConfigTestSuite) TearDownSuite() {
+	err := os.RemoveAll(suite.TempDirectory)
+	suite.Nil(err, "no error deleting temp directory")
+}
+
+func (suite *ConfigTestSuite) TestGetCLIFlagFromVarName() {
+	suite.Equal("basic-auth-user", GetCLIFlagFromVarName("basicauth.user"))
+	suite.Equal("", GetCLIFlagFromVarName("blah.blah.blah"))
+}
+
+func (suite *ConfigTestSuite) TestUpdateFromCLIContext() {
+	var conf *Config
+	var c *cli.Context
+	var err error
+
+	// no config file and empty context, everything should be set to default
+	conf = NewConfig()
+	suite.NotNil(conf)
+	c = getNewContext()
+	err = conf.UpdateFromCLIContext(c)
+	suite.Nil(err)
+	suite.Equal("", conf.GetString("charturl"))
+	suite.Equal(8080, conf.GetInt("port"))
+	suite.Equal(false, conf.GetBool("debug"))
+
+	// no config file and populated context, everything should be set to what is in context
+	conf = NewConfig()
+	suite.NotNil(conf)
+	c = getNewContext()
+	c.Set("chart-url", "https://fakesite.com")
+	c.Set("port", "8081")
+	c.Set("debug", "true")
+	conf.UpdateFromCLIContext(c)
+	suite.Nil(err)
+	suite.Equal("https://fakesite.com", conf.GetString("charturl"))
+	suite.Equal(8081, conf.GetInt("port"))
+	suite.Equal(true, conf.GetBool("debug"))
+
+	// nonexistant config file, error
+	conf = NewConfig()
+	suite.NotNil(conf)
+	c = getNewContext()
+	c.Set("config", "thisisafakefile.yaml")
+	err = conf.UpdateFromCLIContext(c)
+	suite.NotNil(err)
+
+	// config file with bad extension, error
+	conf = NewConfig()
+	suite.NotNil(conf)
+	c = getNewContext()
+	c.Set("config", "../../README.md")
+	err = conf.UpdateFromCLIContext(c)
+	suite.NotNil(err)
+
+	// valid config file and empty context, everything should match config file
+	conf = NewConfig()
+	suite.NotNil(conf)
+	c = getNewContext()
+	c.Set("config", suite.TempConfigFile)
+	err = conf.UpdateFromCLIContext(c)
+	suite.Nil(err)
+	suite.Equal("myuser", conf.GetString("basicauth.user"))
+	suite.Equal("mypass", conf.GetString("basicauth.pass"))
+
+	// valid config file and populated context, context vars should override config file
+	conf = NewConfig()
+	suite.NotNil(conf)
+	c = getNewContext()
+	c.Set("basic-auth-user", "otherdude")
+	c.Set("config", suite.TempConfigFile)
+	err = conf.UpdateFromCLIContext(c)
+	suite.Nil(err)
+	suite.Equal("otherdude", conf.GetString("basicauth.user"))
+	suite.Equal("mypass", conf.GetString("basicauth.pass"))
+}
+
+func getNewContext() *cli.Context {
+	var c *cli.Context
+	app := cli.NewApp()
+	app.Action = func(ctx *cli.Context) {
+		c = ctx
+	}
+	app.Flags = CLIFlags
+	app.Run([]string{"config.test"})
+	return c
+}
+
+func TestConfigTestSuite(t *testing.T) {
+	suite.Run(t, new(ConfigTestSuite))
+}

--- a/pkg/config/vars.go
+++ b/pkg/config/vars.go
@@ -1,0 +1,343 @@
+package config
+
+import (
+	"github.com/urfave/cli"
+)
+
+type (
+	configVar struct {
+		Type    configVarType
+		Default interface{}
+		CLIFlag cli.Flag
+	}
+
+	configVarType string
+)
+
+// Will be populated in init() below
+var CLIFlags []cli.Flag
+
+var (
+	stringType configVarType = "string"
+	intType    configVarType = "int"
+	boolType   configVarType = "bool"
+)
+
+var configVars = map[string]configVar{
+	"genindex": {
+		Type:    boolType,
+		Default: false,
+		CLIFlag: cli.BoolFlag{
+			Name:   "gen-index",
+			Usage:  "generate index.yaml, print to stdout and exit",
+			EnvVar: "GEN_INDEX",
+		},
+	},
+	"debug": {
+		Type:    boolType,
+		Default: false,
+		CLIFlag: cli.BoolFlag{
+			Name:   "debug",
+			Usage:  "show debug messages",
+			EnvVar: "DEBUG",
+		},
+	},
+	"logjson": {
+		Type:    boolType,
+		Default: false,
+		CLIFlag: cli.BoolFlag{
+			Name:   "log-json",
+			Usage:  "output structured logs as json",
+			EnvVar: "LOG_JSON",
+		},
+	},
+	"disablemetrics": {
+		Type:    boolType,
+		Default: false,
+		CLIFlag: cli.BoolFlag{
+			Name:   "disable-metrics",
+			Usage:  "disable Prometheus metrics",
+			EnvVar: "DISABLE_METRICS",
+		},
+	},
+	"disableapi": {
+		Type:    boolType,
+		Default: false,
+		CLIFlag: cli.BoolFlag{
+			Name:   "disable-api",
+			Usage:  "disable all routes prefixed with /api",
+			EnvVar: "DISABLE_API",
+		},
+	},
+	"allowoverwrite": {
+		Type:    boolType,
+		Default: false,
+		CLIFlag: cli.BoolFlag{
+			Name:   "allow-overwrite",
+			Usage:  "allow chart versions to be re-uploaded",
+			EnvVar: "ALLOW_OVERWRITE",
+		},
+	},
+	"port": {
+		Type:    intType,
+		Default: 8080,
+		CLIFlag: cli.IntFlag{
+			Name:   "port",
+			Usage:  "port to listen on",
+			EnvVar: "PORT",
+		},
+	},
+	"charturl": {
+		Type:    stringType,
+		Default: "",
+		CLIFlag: cli.StringFlag{
+			Name:   "chart-url",
+			Usage:  "absolute url for .tgzs in index.yaml",
+			EnvVar: "CHART_URL",
+		},
+	},
+	"basicauth.user": {
+		Type:    stringType,
+		Default: "",
+		CLIFlag: cli.StringFlag{
+			Name:   "basic-auth-user",
+			Usage:  "username for basic http authentication",
+			EnvVar: "BASIC_AUTH_USER",
+		},
+	},
+	"basicauth.pass": {
+		Type:    stringType,
+		Default: "",
+		CLIFlag: cli.StringFlag{
+			Name:   "basic-auth-pass",
+			Usage:  "password for basic http authentication",
+			EnvVar: "BASIC_AUTH_PASS",
+		},
+	},
+	"authanonymousget": {
+		Type:    boolType,
+		Default: false,
+		CLIFlag: cli.BoolFlag{
+			Name:   "auth-anonymous-get",
+			Usage:  "allow anonymous GET operations when auth is used",
+			EnvVar: "AUTH_ANONYMOUS_GET",
+		},
+	},
+	"tls.cert": {
+		Type:    stringType,
+		Default: "",
+		CLIFlag: cli.StringFlag{
+			Name:   "tls-cert",
+			Usage:  "path to tls certificate chain file",
+			EnvVar: "TLS_CERT",
+		},
+	},
+	"tls.key": {
+		Type:    stringType,
+		Default: "",
+		CLIFlag: cli.StringFlag{
+			Name:   "tls-key",
+			Usage:  "path to tls key file",
+			EnvVar: "TLS_KEY",
+		},
+	},
+	"storage.backend": {
+		Type:    stringType,
+		Default: "",
+		CLIFlag: cli.StringFlag{
+			Name:   "storage",
+			Usage:  "storage backend, can be one of: local, amazon, google",
+			EnvVar: "STORAGE",
+		},
+	},
+	"storage.local.rootdir": {
+		Type:    stringType,
+		Default: "",
+		CLIFlag: cli.StringFlag{
+			Name:   "storage-local-rootdir",
+			Usage:  "directory to store charts for local storage backend",
+			EnvVar: "STORAGE_LOCAL_ROOTDIR",
+		},
+	},
+	"storage.amazon.bucket": {
+		Type:    stringType,
+		Default: "",
+		CLIFlag: cli.StringFlag{
+			Name:   "storage-amazon-bucket",
+			Usage:  "s3 bucket to store charts for amazon storage backend",
+			EnvVar: "STORAGE_AMAZON_BUCKET",
+		},
+	},
+	"storage.amazon.prefix": {
+		Type:    stringType,
+		Default: "",
+		CLIFlag: cli.StringFlag{
+			Name:   "storage-amazon-prefix",
+			Usage:  "prefix to store charts for --storage-amazon-bucket",
+			EnvVar: "STORAGE_AMAZON_PREFIX",
+		},
+	},
+	"storage.amazon.region": {
+		Type:    stringType,
+		Default: "",
+		CLIFlag: cli.StringFlag{
+			Name:   "storage-amazon-region",
+			Usage:  "region of --storage-amazon-bucket",
+			EnvVar: "STORAGE_AMAZON_REGION",
+		},
+	},
+	"storage.amazon.endpoint": {
+		Type:    stringType,
+		Default: "",
+		CLIFlag: cli.StringFlag{
+			Name:   "storage-amazon-endpoint",
+			Usage:  "alternative s3 endpoint",
+			EnvVar: "STORAGE_AMAZON_ENDPOINT",
+		},
+	},
+	"storage.amazon.sse": {
+		Type:    stringType,
+		Default: "",
+		CLIFlag: cli.StringFlag{
+			Name:   "storage-amazon-sse",
+			Usage:  "server side encryption algorithm",
+			EnvVar: "STORAGE_AMAZON_SSE",
+		},
+	},
+	"storage.google.bucket": {
+		Type:    stringType,
+		Default: "",
+		CLIFlag: cli.StringFlag{
+			Name:   "storage-google-bucket",
+			Usage:  "gcs bucket to store charts for google storage backend",
+			EnvVar: "STORAGE_GOOGLE_BUCKET",
+		},
+	},
+	"storage.google.prefix": {
+		Type:    stringType,
+		Default: "",
+		CLIFlag: cli.StringFlag{
+			Name:   "storage-google-prefix",
+			Usage:  "prefix to store charts for --storage-google-bucket",
+			EnvVar: "STORAGE_GOOGLE_PREFIX",
+		},
+	},
+	"storage.microsoft.container": {
+		Type:    stringType,
+		Default: "",
+		CLIFlag: cli.StringFlag{
+			Name:   "storage-microsoft-container",
+			Usage:  "container to store charts for microsoft storage backend",
+			EnvVar: "STORAGE_MICROSOFT_CONTAINER",
+		},
+	},
+	"storage.microsoft.prefix": {
+		Type:    stringType,
+		Default: "",
+		CLIFlag: cli.StringFlag{
+			Name:   "storage-microsoft-prefix",
+			Usage:  "prefix to store charts for --storage-microsoft-prefix",
+			EnvVar: "STORAGE_MICROSOFT_PREFIX",
+		},
+	},
+	"storage.alibaba.bucket": {
+		Type:    stringType,
+		Default: "",
+		CLIFlag: cli.StringFlag{
+			Name:   "storage-alibaba-bucket",
+			Usage:  "OSS bucket to store charts for Alibaba Cloud storage backend",
+			EnvVar: "STORAGE_ALIBABA_BUCKET",
+		},
+	},
+	"storage.alibaba.prefix": {
+		Type:    stringType,
+		Default: "",
+		CLIFlag: cli.StringFlag{
+			Name:   "storage-alibaba-prefix",
+			Usage:  "prefix to store charts for --storage-alibaba-cloud-bucket",
+			EnvVar: "STORAGE_ALIBABA_PREFIX",
+		},
+	},
+	"storage.alibaba.endpoint": {
+		Type:    stringType,
+		Default: "",
+		CLIFlag: cli.StringFlag{
+			Name:   "storage-alibaba-endpoint",
+			Usage:  "OSS endpoint",
+			EnvVar: "STORAGE_ALIBABA_ENDPOINT",
+		},
+	},
+	"storage.alibaba.sse": {
+		Type:    stringType,
+		Default: "",
+		CLIFlag: cli.StringFlag{
+			Name:   "storage-alibaba-sse",
+			Usage:  "server side encryption algorithm for Alibaba Cloud storage backend, AES256 or KMS",
+			EnvVar: "STORAGE_ALIBABA_SSE",
+		},
+	},
+	"chartpostformfieldname": {
+		Type:    stringType,
+		Default: "chart",
+		CLIFlag: cli.StringFlag{
+			Name:   "chart-post-form-field-name",
+			Usage:  "form field which will be queried for the chart file content",
+			EnvVar: "CHART_POST_FORM_FIELD_NAME",
+		},
+	},
+	"provpostformfieldname": {
+		Type:    stringType,
+		Default: "prov",
+		CLIFlag: cli.StringFlag{
+			Name:   "prov-post-form-field-name",
+			Usage:  "form field which will be queried for the provenance file content",
+			EnvVar: "PROV_POST_FORM_FIELD_NAME",
+		},
+	},
+	"indexlimit": {
+		Type:    intType,
+		Default: 0,
+		CLIFlag: cli.IntFlag{
+			Name:   "index-limit",
+			Usage:  "parallel scan limit for the repo indexer",
+			EnvVar: "INDEX_LIMIT",
+		},
+	},
+	"contextpath": {
+		Type:    stringType,
+		Default: "",
+		CLIFlag: cli.StringFlag{
+			Name:   "context-path",
+			Usage:  "base context path",
+			EnvVar: "CONTEXT_PATH",
+		},
+	},
+	"depth": {
+		Type:    intType,
+		Default: 0,
+		CLIFlag: cli.IntFlag{
+			Name:   "depth",
+			Usage:  "levels of nested repos for multitenancy",
+			EnvVar: "DEPTH",
+		},
+	},
+}
+
+func populateCLIFlags() {
+	CLIFlags = []cli.Flag{
+		cli.StringFlag{
+			Name:   "config, c",
+			Usage:  "chartmuseum configuration file",
+			EnvVar: "CONFIG",
+		},
+	}
+	for _, configVar := range configVars {
+		if flag := configVar.CLIFlag; flag != nil {
+			CLIFlags = append(CLIFlags, flag)
+		}
+	}
+}
+
+func init() {
+	populateCLIFlags()
+}


### PR DESCRIPTION
Fixes #94. Is a prerequisite for #93 and #86.

Added the ability to specify a yaml config file using the `-c/--config` flag.

The order of configuration variable overrides is the following:

- config file
- environment variable
- command line flag

Uses the [viper](https://github.com/spf13/viper) package to parse the configuration. Viper allows for remote configuration in both etcd and Consul, which will become important to support users who want to change repo-specific config on-the-fly (public vs private repo etc).