### PR TITLE
Webhook impelemtation

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -20,3 +20,4 @@ index.yaml
 mirror/
 testbin/
 vendor/
+.vscode

--- a/cmd/chartmuseum/main.go
+++ b/cmd/chartmuseum/main.go
@@ -6,11 +6,10 @@ import (
 	"os"
 	"strings"
 
-	"github.com/kubernetes-helm/chartmuseum/pkg/integration"
-
 	"github.com/kubernetes-helm/chartmuseum/pkg/chartmuseum"
 	"github.com/kubernetes-helm/chartmuseum/pkg/config"
 	"github.com/kubernetes-helm/chartmuseum/pkg/event"
+	"github.com/kubernetes-helm/chartmuseum/pkg/integration"
 	"github.com/kubernetes-helm/chartmuseum/pkg/storage"
 	"github.com/urfave/cli"
 )

--- a/cmd/chartmuseum/main.go
+++ b/cmd/chartmuseum/main.go
@@ -67,6 +67,7 @@ func cliHandler(c *cli.Context) {
 		IndexLimit:             conf.GetInt("indexlimit"),
 		Depth:                  conf.GetInt("depth"),
 		EventEmitter:           event.NewEventEmitter(),
+		IntegrationAPIEnabled:  !conf.GetBool("integration.disable"),
 	}
 
 	server, err := newServer(options)

--- a/cmd/chartmuseum/main.go
+++ b/cmd/chartmuseum/main.go
@@ -6,10 +6,12 @@ import (
 	"os"
 	"strings"
 
+	"github.com/kubernetes-helm/chartmuseum/pkg/integration"
+
 	"github.com/kubernetes-helm/chartmuseum/pkg/chartmuseum"
 	"github.com/kubernetes-helm/chartmuseum/pkg/config"
+	"github.com/kubernetes-helm/chartmuseum/pkg/event"
 	"github.com/kubernetes-helm/chartmuseum/pkg/storage"
-
 	"github.com/urfave/cli"
 )
 
@@ -44,6 +46,8 @@ func cliHandler(c *cli.Context) {
 
 	backend := backendFromConfig(conf)
 
+	initIntegrationStorage()
+
 	options := chartmuseum.ServerOptions{
 		StorageBackend:         backend,
 		ChartURL:               conf.GetString("charturl"),
@@ -63,6 +67,7 @@ func cliHandler(c *cli.Context) {
 		GenIndex:               conf.GetBool("genindex"),
 		IndexLimit:             conf.GetInt("indexlimit"),
 		Depth:                  conf.GetInt("depth"),
+		EventEmitter:           event.NewEventEmitter(),
 	}
 
 	server, err := newServer(options)
@@ -71,6 +76,10 @@ func cliHandler(c *cli.Context) {
 	}
 
 	server.Listen(conf.GetInt("port"))
+}
+
+func initIntegrationStorage() {
+	integration.InitStorage()
 }
 
 func backendFromConfig(conf *config.Config) storage.Backend {

--- a/pkg/chartmuseum/router/router.go
+++ b/pkg/chartmuseum/router/router.go
@@ -50,9 +50,10 @@ type (
 )
 
 var (
-	RepoPullAction   action = "pull"
-	RepoPushAction   action = "push"
-	SystemInfoAction action = "sysinfo"
+	RepoPullAction       action = "pull"
+	RepoPushAction       action = "push"
+	SystemInfoAction     action = "sysinfo"
+	APIIntegrationAction action = "chartmuseum:api:integration"
 )
 
 // NewRouter creates a new Router instance

--- a/pkg/chartmuseum/server.go
+++ b/pkg/chartmuseum/server.go
@@ -30,6 +30,7 @@ type (
 		IndexLimit             int
 		Depth                  int
 		EventEmitter           *event.EventEmitter
+		IntegrationAPIEnabled  bool
 	}
 
 	// Server is a generic interface for web servers
@@ -72,6 +73,7 @@ func NewServer(options ServerOptions) (Server, error) {
 		EnableAPI:              options.EnableAPI,
 		AllowOverwrite:         options.AllowOverwrite,
 		EventEmitter:           options.EventEmitter,
+		IntegrationAPIEnabled:  options.IntegrationAPIEnabled,
 	})
 
 	return server, err

--- a/pkg/chartmuseum/server.go
+++ b/pkg/chartmuseum/server.go
@@ -4,6 +4,7 @@ import (
 	cm_logger "github.com/kubernetes-helm/chartmuseum/pkg/chartmuseum/logger"
 	cm_router "github.com/kubernetes-helm/chartmuseum/pkg/chartmuseum/router"
 	mt "github.com/kubernetes-helm/chartmuseum/pkg/chartmuseum/server/multitenant"
+	"github.com/kubernetes-helm/chartmuseum/pkg/event"
 	"github.com/kubernetes-helm/chartmuseum/pkg/storage"
 )
 
@@ -28,6 +29,7 @@ type (
 		GenIndex               bool
 		IndexLimit             int
 		Depth                  int
+		EventEmitter           *event.EventEmitter
 	}
 
 	// Server is a generic interface for web servers
@@ -69,6 +71,7 @@ func NewServer(options ServerOptions) (Server, error) {
 		GenIndex:               options.GenIndex,
 		EnableAPI:              options.EnableAPI,
 		AllowOverwrite:         options.AllowOverwrite,
+		EventEmitter:           options.EventEmitter,
 	})
 
 	return server, err

--- a/pkg/chartmuseum/server/multitenant/routes.go
+++ b/pkg/chartmuseum/server/multitenant/routes.go
@@ -24,6 +24,9 @@ func (s *MultiTenantServer) Routes() []*cm_router.Route {
 		{"POST", "/api/:repo/charts", s.postRequestHandler, cm_router.RepoPushAction},
 		{"POST", "/api/:repo/prov", s.postProvenanceFileRequestHandler, cm_router.RepoPushAction},
 		{"DELETE", "/api/:repo/charts/:name/:version", s.deleteChartVersionRequestHandler, cm_router.RepoPushAction},
+		{"GET", "/api/:repo/integrations", s.getAllIntegrations, cm_router.APIIntegrationAction},
+		{"POST", "/api/:repo/integrations", s.createIntegration, cm_router.APIIntegrationAction},
+		{"DELETE", "/api/:repo/integrations/:name", s.deleteIntegration, cm_router.APIIntegrationAction},
 	}
 
 	routes = append(routes, serverInfoRoutes...)

--- a/pkg/chartmuseum/server/multitenant/routes.go
+++ b/pkg/chartmuseum/server/multitenant/routes.go
@@ -24,6 +24,9 @@ func (s *MultiTenantServer) Routes() []*cm_router.Route {
 		{"POST", "/api/:repo/charts", s.postRequestHandler, cm_router.RepoPushAction},
 		{"POST", "/api/:repo/prov", s.postProvenanceFileRequestHandler, cm_router.RepoPushAction},
 		{"DELETE", "/api/:repo/charts/:name/:version", s.deleteChartVersionRequestHandler, cm_router.RepoPushAction},
+	}
+
+	integrationManipulationRoutes := []*cm_router.Route{
 		{"GET", "/api/:repo/integrations", s.getAllIntegrations, cm_router.APIIntegrationAction},
 		{"POST", "/api/:repo/integrations", s.createIntegration, cm_router.APIIntegrationAction},
 		{"DELETE", "/api/:repo/integrations/:name", s.deleteIntegration, cm_router.APIIntegrationAction},
@@ -34,6 +37,9 @@ func (s *MultiTenantServer) Routes() []*cm_router.Route {
 
 	if s.APIEnabled {
 		routes = append(routes, chartManipulationRoutes...)
+	}
+	if s.IntegrationAPIEnabled {
+		routes = append(routes, integrationManipulationRoutes...)
 	}
 
 	return routes

--- a/pkg/chartmuseum/server/multitenant/server.go
+++ b/pkg/chartmuseum/server/multitenant/server.go
@@ -34,6 +34,7 @@ type (
 		IndexCache             map[string]*cachedIndexFile
 		IndexCacheKeyLock      *sync.Mutex
 		EventEmitter           *event.EventEmitter
+		IntegrationAPIEnabled  bool
 	}
 
 	// MultiTenantServerOptions are options for constructing a MultiTenantServer
@@ -49,6 +50,7 @@ type (
 		AllowOverwrite         bool
 		EnableAPI              bool
 		EventEmitter           *event.EventEmitter
+		IntegrationAPIEnabled  bool
 	}
 )
 
@@ -73,6 +75,7 @@ func NewMultiTenantServer(options MultiTenantServerOptions) (*MultiTenantServer,
 		IndexCache:             map[string]*cachedIndexFile{},
 		IndexCacheKeyLock:      &sync.Mutex{},
 		EventEmitter:           options.EventEmitter,
+		IntegrationAPIEnabled:  options.IntegrationAPIEnabled,
 	}
 
 	server.Router.SetRoutes(server.Routes())

--- a/pkg/chartmuseum/server/multitenant/server.go
+++ b/pkg/chartmuseum/server/multitenant/server.go
@@ -6,6 +6,8 @@ import (
 	"strings"
 	"sync"
 
+	"github.com/kubernetes-helm/chartmuseum/pkg/event"
+
 	cm_logger "github.com/kubernetes-helm/chartmuseum/pkg/chartmuseum/logger"
 	cm_router "github.com/kubernetes-helm/chartmuseum/pkg/chartmuseum/router"
 	"github.com/kubernetes-helm/chartmuseum/pkg/storage"
@@ -31,6 +33,7 @@ type (
 		Limiter                chan struct{}
 		IndexCache             map[string]*cachedIndexFile
 		IndexCacheKeyLock      *sync.Mutex
+		EventEmitter           *event.EventEmitter
 	}
 
 	// MultiTenantServerOptions are options for constructing a MultiTenantServer
@@ -45,6 +48,7 @@ type (
 		GenIndex               bool
 		AllowOverwrite         bool
 		EnableAPI              bool
+		EventEmitter           *event.EventEmitter
 	}
 )
 
@@ -68,6 +72,7 @@ func NewMultiTenantServer(options MultiTenantServerOptions) (*MultiTenantServer,
 		Limiter:                make(chan struct{}, options.IndexLimit),
 		IndexCache:             map[string]*cachedIndexFile{},
 		IndexCacheKeyLock:      &sync.Mutex{},
+		EventEmitter:           options.EventEmitter,
 	}
 
 	server.Router.SetRoutes(server.Routes())

--- a/pkg/config/vars.go
+++ b/pkg/config/vars.go
@@ -321,6 +321,15 @@ var configVars = map[string]configVar{
 			EnvVar: "DEPTH",
 		},
 	},
+	"integration.disable": {
+		Type:    boolType,
+		Default: false,
+		CLIFlag: cli.BoolFlag{
+			Name:   "disable-integration",
+			Usage:  "Set true to disable integration endpoints",
+			EnvVar: "DISABLE_INTEGRATION",
+		},
+	},
 }
 
 func populateCLIFlags() {

--- a/pkg/event/emitter.go
+++ b/pkg/event/emitter.go
@@ -1,0 +1,26 @@
+package event
+
+type (
+	// IEventEmitter standard interface for event emitter
+	IEventEmitter interface {
+		Emit(ev interface{})
+	}
+
+	// EventEmitter empty struct
+	EventEmitter struct{}
+)
+
+// Emit event from EventEmitter
+func (emitter *EventEmitter) Emit(ev *Event) {
+	action := ev.Action
+	for _, pair := range Handler.Events {
+		if action == pair.Action {
+			pair.Handler(ev)
+		}
+	}
+}
+
+// NewEventEmitter create new EventEmitter
+func NewEventEmitter() *EventEmitter {
+	return &EventEmitter{}
+}

--- a/pkg/event/event.go
+++ b/pkg/event/event.go
@@ -1,0 +1,22 @@
+package event
+
+import (
+	cm_logger "github.com/kubernetes-helm/chartmuseum/pkg/chartmuseum/logger"
+)
+
+var (
+
+	// ChartPushedEventName throws when chart successfully pushed to repo
+	ChartPushedEventName = "chart:pushed"
+	// ChartDeletedEventName throws when chart deleted from repo
+	ChartDeletedEventName = "chart:deleted"
+)
+
+type (
+	// Event struct defined the action and the additional data from the event
+	Event struct {
+		Action string
+		Logger cm_logger.LoggingFn
+		Data   map[string]interface{}
+	}
+)

--- a/pkg/event/handler.go
+++ b/pkg/event/handler.go
@@ -1,0 +1,123 @@
+package event
+
+import (
+	"fmt"
+	"time"
+
+	"github.com/kubernetes-helm/chartmuseum/pkg/webhook"
+
+	cm_logger "github.com/kubernetes-helm/chartmuseum/pkg/chartmuseum/logger"
+	"github.com/kubernetes-helm/chartmuseum/pkg/integration"
+)
+
+var Handler *EventHandler
+
+type (
+
+	// IEventHandler standard interface for event subscription
+	IEventHandler interface {
+		On(string, interface{})
+	}
+
+	// EventHandler have all subscribed events
+	EventHandler struct {
+		Events []ActionHandlerPair
+	}
+
+	// ActionHandlerPair event name and function handler struct
+	ActionHandlerPair struct {
+		Action  string
+		Handler func(interface{})
+	}
+)
+
+func init() {
+	Handler = &EventHandler{}
+	Handler.On(ChartPushedEventName, onChartPushedEvent)
+	Handler.On(ChartDeletedEventName, onChartDeletedEvent)
+}
+
+// On subscribe to event
+func (e *EventHandler) On(action string, handler func(interface{})) {
+	e.Events = append(e.Events, ActionHandlerPair{
+		Action:  action,
+		Handler: handler,
+	})
+}
+
+func onChartPushedEvent(ev interface{}) {
+	event := ev.(*Event)
+	db := integration.DAL
+	logger := event.Logger
+	message := fmt.Sprintf("Received event")
+	logger(cm_logger.DebugLevel, message,
+		"Event_Name", event.Action,
+	)
+	chartName := event.Data["name"].(string)
+	prefix := event.Data["repo"].(string)
+	integrations, _ := db.GetIntegrationsMatchResourceByRegex(prefix, chartName, logger)
+	logger(cm_logger.DebugLevel, fmt.Sprintf("Got %d integrations\n", len(integrations)))
+	for _, integ := range integrations {
+		if matchEventActionWithIntegrationTriggers(event, integ) {
+			wh := newWebhook(event, integ, logger)
+			wh.SendHook(integ.Spec.URL, integ.Spec.Secret, logger)
+		}
+	}
+}
+
+func onChartDeletedEvent(ev interface{}) {
+	event := ev.(*Event)
+	db := integration.DAL
+	logger := event.Logger
+	message := fmt.Sprintf("Received event")
+	logger(cm_logger.DebugLevel, message,
+		"Event_Name", event.Action,
+	)
+	chartName := event.Data["name"].(string)
+	prefix := event.Data["repo"].(string)
+	integrations, _ := db.GetIntegrationsMatchResourceByRegex(prefix, chartName, logger)
+	for _, integ := range integrations {
+		if matchEventActionWithIntegrationTriggers(event, integ) {
+			wh := newWebhook(event, integ, logger)
+			wh.SendHook(integ.Spec.URL, integ.Spec.Secret, logger)
+		}
+	}
+}
+
+func newWebhook(ev *Event, in *integration.Integration, logger cm_logger.LoggingFn) webhook.Webhook {
+	message := fmt.Sprintf("Preparing webhook from integration")
+	logger(cm_logger.DebugLevel, message,
+		"Name", in.Metadata.Name,
+	)
+	return webhook.Webhook{
+		Version: webhook.Version,
+		Kind:    webhook.Kind,
+		Metadata: webhook.WebhookMetadata{
+			Action: ev.Action,
+			Integration: webhook.WebhookMetadataIntegration{
+				ID:   in.Metadata.ID,
+				Name: in.Metadata.Name,
+			},
+			Labels:    in.Metadata.Labels,
+			Timestamp: time.Now().String(),
+		},
+		Spec: webhook.WebhookSpec{
+			Resource: webhook.WebhookSpecResource{
+				Type: "repo",
+				Name: ev.Data["repo"].(string),
+			},
+			Chart: ev.Data["filename"].(string),
+		},
+	}
+}
+
+func matchEventActionWithIntegrationTriggers(ev *Event, in *integration.Integration) bool {
+	action := ev.Action
+	triggers := in.Spec.Triggers
+	for _, t := range triggers {
+		if action == t {
+			return true
+		}
+	}
+	return false
+}

--- a/pkg/integration/inmemory.go
+++ b/pkg/integration/inmemory.go
@@ -1,0 +1,135 @@
+package integration
+
+import (
+	"encoding/json"
+	"fmt"
+	"regexp"
+
+	cm_logger "github.com/kubernetes-helm/chartmuseum/pkg/chartmuseum/logger"
+	"github.com/tidwall/buntdb"
+)
+
+type (
+	Inmemory struct {
+		DB *buntdb.DB
+	}
+)
+
+func initInMemoryStorage() IntegrationStorage {
+	db, _ := buntdb.Open(":memory:")
+	return &Inmemory{
+		DB: db,
+	}
+}
+
+func (d *Inmemory) Insert(i Integration, logger cm_logger.LoggingFn) error {
+	str, err := integrationToString(&i)
+	if err != nil {
+		return err
+	}
+	return d.DB.Update(func(tx *buntdb.Tx) error {
+		_, _, err := tx.Set(i.Metadata.Name, str, nil)
+		return err
+	})
+}
+
+func integrationToString(i *Integration) (string, error) {
+	b, err := json.Marshal(i)
+	if err != nil {
+		return "", err
+	}
+	return string(b), nil
+}
+
+func stringToIntegration(str string) (*Integration, error) {
+	result := &Integration{}
+	b := []byte(str)
+	err := json.Unmarshal(b, result)
+	if err != nil {
+		return nil, err
+	}
+	return result, nil
+}
+
+func (d *Inmemory) Find(name string, logger cm_logger.LoggingFn) (*Integration, error) {
+	result := &Integration{}
+	err := d.DB.View(func(tx *buntdb.Tx) error {
+		val, err := tx.Get(name)
+		result, err = stringToIntegration(val)
+		if err != nil {
+			return err
+		}
+		logMessage := "Found integration"
+		logger(cm_logger.DebugLevel, logMessage, "Name", result.Metadata.Name)
+		return nil
+	})
+	if err != nil {
+		return nil, err
+	}
+	return result, nil
+}
+
+func (d *Inmemory) GetIntegrationsByResourceName(repo string, logger cm_logger.LoggingFn) ([]*Integration, error) {
+	logMessage := "GetIntegrationsByResourceName"
+	logger(cm_logger.DebugLevel, logMessage, "Repo", repo)
+	result := []*Integration{}
+	err := d.DB.View(func(tx *buntdb.Tx) error {
+		err := tx.Ascend("", func(key, value string) bool {
+			integration, _ := stringToIntegration(value)
+			resource := integration.Spec.Resource
+			logger(cm_logger.DebugLevel, logMessage, "Resource", resource)
+			if resource.Repo == repo {
+				result = append(result, integration)
+			}
+			return true
+		})
+		return err
+	})
+	if err != nil {
+		return nil, err
+	}
+	return result, nil
+}
+func (d *Inmemory) GetIntegrationsMatchResourceByRegex(repo string, chart string, logger cm_logger.LoggingFn) ([]*Integration, error) {
+	logMessage := "GetIntegrationsMatchResourceByRegex"
+	logger(cm_logger.DebugLevel, logMessage, "Repo", repo, "Chart", chart)
+	result := []*Integration{}
+	err := d.DB.View(func(tx *buntdb.Tx) error {
+		err := tx.Ascend("", func(key, value string) bool {
+			integration, _ := stringToIntegration(value)
+			logger(cm_logger.DebugLevel, "Checking resource", "Name", integration.Metadata.Name)
+			resource := integration.Spec.Resource
+			name := fmt.Sprintf("%s/%s", repo, chart)
+			pattern := resource.Repo
+			if resource.Chart != "" {
+				pattern += fmt.Sprintf("/%s", resource.Chart)
+			}
+			logger(cm_logger.DebugLevel, "Required match", "Pattern", pattern)
+			res, _ := regexp.MatchString(pattern, name)
+			if res {
+				logger(cm_logger.DebugLevel, "Matched!")
+				result = append(result, integration)
+			}
+			return true
+		})
+		return err
+	})
+	if err != nil {
+		return nil, err
+	}
+	return result, nil
+}
+
+func (d *Inmemory) Remove(name string, logger cm_logger.LoggingFn) error {
+	err := d.DB.Update(func(tx *buntdb.Tx) error {
+		_, err := tx.Delete(name)
+		if err != nil {
+			return err
+		}
+		return nil
+	})
+	if err != nil {
+		return err
+	}
+	return nil
+}

--- a/pkg/integration/integration.go
+++ b/pkg/integration/integration.go
@@ -1,0 +1,70 @@
+package integration
+
+import (
+	uuid "github.com/satori/go.uuid"
+)
+
+type (
+	Integration struct {
+		Version  string              `json:"version"`
+		Kind     string              `json:"kind"`
+		Metadata IntegrationMetadata `json:"metadata"`
+		Spec     IntegrationSpec     `json:"spec"`
+	}
+
+	IntegrationMetadata struct {
+		Name   string            `json:"name"`
+		ID     string            `json:"id"`
+		Labels map[string]string `json:"labels"`
+	}
+
+	IntegrationSpec struct {
+		URL      string              `json:"url"`
+		Secret   string              `json:"secret"`
+		Triggers []string            `json:"triggers"`
+		Resource IntegrationResource `json:"resource"`
+	}
+
+	IntegrationResource struct {
+		Chart string `json:"chart"`
+		Repo  string `json:"repo"`
+	}
+
+	IntegrationOptions struct {
+		Name     string            `json:"name"`
+		Labels   map[string]string `json:"labels"`
+		URL      string            `json:"url"`
+		Secret   string            `json:"secret"`
+		Chart    string            `json:"chart"`
+		Repo     string            `json:"repo"`
+		Triggers []string          `json:"triggers"`
+	}
+)
+
+func NewIntegration(spec IntegrationSpec, meta IntegrationMetadata) Integration {
+	return Integration{
+		Kind:     integrationKind,
+		Version:  integrationVersion,
+		Metadata: meta,
+		Spec:     spec,
+	}
+}
+
+func NewIntegrationFromOptions(opt *IntegrationOptions) Integration {
+	meta := IntegrationMetadata{
+		Name:   opt.Name,
+		ID:     uuid.NewV4().String(),
+		Labels: opt.Labels,
+	}
+	resource := IntegrationResource{
+		Repo:  opt.Repo,
+		Chart: opt.Chart,
+	}
+	spec := IntegrationSpec{
+		Triggers: opt.Triggers,
+		Resource: resource,
+		URL:      opt.URL,
+		Secret:   opt.Secret,
+	}
+	return NewIntegration(spec, meta)
+}

--- a/pkg/integration/storage.go
+++ b/pkg/integration/storage.go
@@ -1,0 +1,56 @@
+package integration
+
+import (
+	cm_logger "github.com/kubernetes-helm/chartmuseum/pkg/chartmuseum/logger"
+)
+
+var (
+	integrationKind    = "Integration"
+	integrationVersion = "v1"
+	DAL                *Storage
+)
+
+func InitStorage() {
+	storage := initInMemoryStorage()
+	DAL = &Storage{
+		db: storage,
+	}
+}
+
+type (
+	IntegrationStorage interface {
+		Insert(Integration, cm_logger.LoggingFn) error
+		Find(string, cm_logger.LoggingFn) (*Integration, error)
+		GetIntegrationsByResourceName(string, cm_logger.LoggingFn) ([]*Integration, error)
+		GetIntegrationsMatchResourceByRegex(string, string, cm_logger.LoggingFn) ([]*Integration, error)
+		Remove(string, cm_logger.LoggingFn) error
+	}
+
+	Database struct {
+		IntegrationIDTable map[string]Integration
+	}
+
+	Storage struct {
+		db IntegrationStorage
+	}
+)
+
+func (s *Storage) Insert(i Integration, logger cm_logger.LoggingFn) error {
+	return s.db.Insert(i, logger)
+}
+
+func (s *Storage) Find(name string, logger cm_logger.LoggingFn) (*Integration, error) {
+	return s.db.Find(name, logger)
+}
+
+func (s *Storage) GetIntegrationsByResourceName(repo string, logger cm_logger.LoggingFn) ([]*Integration, error) {
+	return s.db.GetIntegrationsByResourceName(repo, logger)
+}
+
+func (s *Storage) GetIntegrationsMatchResourceByRegex(repo string, chart string, logger cm_logger.LoggingFn) ([]*Integration, error) {
+	return s.db.GetIntegrationsMatchResourceByRegex(repo, chart, logger)
+}
+
+func (s *Storage) Remove(name string, logger cm_logger.LoggingFn) error {
+	return s.db.Remove(name, logger)
+}

--- a/pkg/repo/chart.go
+++ b/pkg/repo/chart.go
@@ -69,6 +69,14 @@ func ChartVersionFromStorageObject(object storage.Object) (*helm_repo.ChartVersi
 	return chartVersion, nil
 }
 
+func ChartFromContent(content []byte) (*helm_chart.Chart, error) {
+	chart, err := chartFromContent(content)
+	if err != nil {
+		return nil, err
+	}
+	return chart, nil
+}
+
 func chartFromContent(content []byte) (*helm_chart.Chart, error) {
 	chart, err := chartutil.LoadArchive(bytes.NewBuffer(content))
 	return chart, err

--- a/pkg/webhook/webhook.go
+++ b/pkg/webhook/webhook.go
@@ -1,0 +1,81 @@
+package webhook
+
+import (
+	"bytes"
+	"crypto/hmac"
+	"crypto/sha256"
+	"encoding/base64"
+	"encoding/json"
+	"fmt"
+	"net/http"
+
+	cm_logger "github.com/kubernetes-helm/chartmuseum/pkg/chartmuseum/logger"
+)
+
+var (
+	Version = "v1"
+	Kind    = "Webhook"
+)
+
+type (
+	Webhook struct {
+		Version  string          `json:"version"`
+		Kind     string          `json:"kind"`
+		Metadata WebhookMetadata `json:"metadata"`
+		Spec     WebhookSpec     `json:"spec"`
+	}
+
+	WebhookMetadata struct {
+		Action      string                     `json:"action"`
+		Labels      map[string]string          `json:"labels"`
+		Timestamp   string                     `json:"timestamp"`
+		Integration WebhookMetadataIntegration `json:"integration"`
+	}
+
+	WebhookSpec struct {
+		Chart    string              `json:"chart"`
+		Resource WebhookSpecResource `json:"resource"`
+	}
+
+	WebhookSpecResource struct {
+		Type string `json:"type"`
+		Name string `json:"name"`
+	}
+
+	WebhookMetadataIntegration struct {
+		ID   string `json:"id"`
+		Name string `json:"name"`
+	}
+)
+
+func (wh *Webhook) SendHook(url string, secret string, logger cm_logger.LoggingFn) {
+	message := fmt.Sprintf("Preparing to send hook")
+	logger(cm_logger.DebugLevel, message,
+		"URL", url,
+	)
+	mJSON, _ := json.Marshal(wh)
+	contentReader := bytes.NewReader(mJSON)
+	req, _ := http.NewRequest("POST", url, contentReader)
+	req.Header.Set("X-Chartmuseum-HMAC", getHMACHeaderToRequest(req, secret, mJSON, logger))
+	req.Header.Set("Content-Type", "application/json")
+	client := &http.Client{}
+	resp, _ := client.Do(req)
+	logger(cm_logger.DebugLevel, "Webhook been sent", "Status_Code", resp.StatusCode)
+}
+
+// Calc HMAC using Sha-256 using the secret string from the integration
+// Set the result as header of the request
+func getHMACHeaderToRequest(req *http.Request, secret string, payload []byte, logger cm_logger.LoggingFn) string {
+	if secret != "" {
+		message := fmt.Sprintf("Singing payload with secret")
+		logger(cm_logger.DebugLevel, message,
+			"Secret", secret,
+		)
+		key := []byte(secret)
+		mac := hmac.New(sha256.New, key)
+		mac.Write(payload)
+		hmac := base64.URLEncoding.EncodeToString(mac.Sum(nil))
+		return hmac
+	}
+	return ""
+}

--- a/webhook.md
+++ b/webhook.md
@@ -1,0 +1,38 @@
+This is temporary documentation and it should not be merged
+
+## Configure webhook
+* Run Chartmuseum
+* Get webhook url
+* Create integration on repo `organization/repository/chart-name` by:
+```
+curl -X POST \
+  http://localhost:8080/api/org/repo/integrations \
+  -d '{
+	"name": "name",
+    "url":"...",
+    "triggers": [
+        "chart:pushed",
+        "chart:deleted"
+    ],
+	"chart": "*"
+}'
+```
+* Push/Delete chart
+
+### Run locally
+`dahyphenn/webhook.site` allows you to receive hooks with pretty nice visualization.  
+Just run: `docker run -d --init -p 80:80 dahyphenn/webhook.site`
+
+* Validate HMAC using node.js
+```
+'use strict'
+
+const crypto = require('crypto')
+const obj = {} // The paylad your received
+const   text = JSON.stringify(obj)
+const   key = 'YOUR-SECRET-KEY'
+let   hash
+
+hash = crypto.createHmac('sha256', key).update(text).digest('base64')
+console.log(hash)
+```


### PR DESCRIPTION
This PR related to [#83](https://github.com/kubernetes-helm/chartmuseum/issues/83)
This is not a merge candidate but get feedback asap.

* Add event emitter and event handles basic implementation. Considering to use [olebedev/emitter](https://github.com/olebedev/emitter)

* Add implementation of in-memory integration storage.


* Implement webhook HTTP POST request logic includes HMAC header as payload signed by given secret key

* Add end-points to Create, Delete and Get integrations

* TBD:
  * More complex Integration CRUD
  * sql implementation as well
  * Tests