### PR TITLE
Removed debug binary from cmd/chartmuseum

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -21,3 +21,4 @@ index.yaml
 mirror/
 testbin/
 vendor/
+cmd/chartmuseum/debug


### PR DESCRIPTION
While going through the code I realized that the debug binary was checked in at `cmd/chartmuseum` this project. 
This pull request removed the debug binary and added an entry in `.gitignore` to ignore it. 