### PR TITLE
Use default 'chart' and 'prov' form fields

### DIFF
--- a/pkg/chartmuseum/server/multitenant/handlers.go
+++ b/pkg/chartmuseum/server/multitenant/handlers.go
@@ -12,10 +12,10 @@ import (
 )
 
 var (
-	objectSavedResponse        = gin.H{"saved": true}
-	objectDeletedResponse      = gin.H{"deleted": true}
-	healthCheckResponse        = gin.H{"healthy": true}
-	welcomePageHTML            = []byte(`<!DOCTYPE html>
+	objectSavedResponse   = gin.H{"saved": true}
+	objectDeletedResponse = gin.H{"deleted": true}
+	healthCheckResponse   = gin.H{"healthy": true}
+	welcomePageHTML       = []byte(`<!DOCTYPE html>
 <html>
 <head>
 <title>Welcome to ChartMuseum!</title>
@@ -124,7 +124,6 @@ func (server *MultiTenantServer) getChartVersionRequestHandler(c *gin.Context) {
 	c.JSON(200, chartVersion)
 }
 
-
 func (server *MultiTenantServer) deleteChartVersionRequestHandler(c *gin.Context) {
 	repo := c.Param("repo")
 	name := c.Param("name")
@@ -195,7 +194,9 @@ func (server *MultiTenantServer) postPackageAndProvenanceRequestHandler(c *gin.C
 	}
 
 	ffp := []fieldFuncPair{
+		{defaultFormField, cm_repo.ChartPackageFilenameFromContent},
 		{server.ChartPostFormFieldName, cm_repo.ChartPackageFilenameFromContent},
+		{defaultProvField, cm_repo.ProvenanceFilenameFromContent},
 		{server.ProvPostFormFieldName, cm_repo.ProvenanceFilenameFromContent},
 	}
 

--- a/pkg/chartmuseum/server/multitenant/server.go
+++ b/pkg/chartmuseum/server/multitenant/server.go
@@ -16,6 +16,11 @@ var (
 	exit = os.Exit
 )
 
+const (
+	defaultFormField = "chart"
+	defaultProvField = "prov"
+)
+
 type (
 	// MultiTenantServer contains a Logger, Router, storage backend and object cache
 	MultiTenantServer struct {


### PR DESCRIPTION
Even if chartmuseum is configured with a form field through
CHART_POST_FORM_FIELD_NAME or PROV_POST_FORM_FIELD_NAME, also allow
posting with default 'chart' and 'prov' form field values.

This simplifies other clients like helm push which does not
know about the specific server setting.

closes #124