### PR TITLE
Fixing bug #138 maintainer name in provenance files

### DIFF
--- a/pkg/repo/provenance.go
+++ b/pkg/repo/provenance.go
@@ -32,8 +32,8 @@ func ProvenanceFilenameFromContent(content []byte) (string, error) {
 	contentStr := string(content[:])
 
 	hasPGPBegin := strings.HasPrefix(contentStr, "-----BEGIN PGP SIGNED MESSAGE-----")
-	nameMatch := regexp.MustCompile("name:[ *](.+)").FindStringSubmatch(contentStr)
-	versionMatch := regexp.MustCompile("version:[ *](.+)").FindStringSubmatch(contentStr)
+	nameMatch := regexp.MustCompile("^name:[ *](.+)").FindStringSubmatch(contentStr)
+	versionMatch := regexp.MustCompile("^version:[ *](.+)").FindStringSubmatch(contentStr)
 
 	if !hasPGPBegin || len(nameMatch) != 2 || len(versionMatch) != 2 {
 		return "", ErrorInvalidProvenanceFile

--- a/pkg/repo/provenance_test.go
+++ b/pkg/repo/provenance_test.go
@@ -30,6 +30,30 @@ FUyR0Eszw/x3No0DdPuH3fo0ShamW9eOFnXIgWqvaeSJthTC5WO5mlSGNEunJKft
 HjQLzdEWppyu55ZS6/oIJdVC2GjUa/PZmKkhYwsMvaWYv+jZWFfhZn8fPYEF0qI=
 =/cXn
 -----END PGP SIGNATURE-----`)
+	 goodContentWithMatainerName := []byte(`-----BEGIN PGP SIGNED MESSAGE-----
+Hash: SHA512
+
+description: Buildpack application builder for Hephy Workflow.
+home: https://github.com/teamhephy/slugbuilder
+maintainers:
+- - email: team@teamhephy.com
+  name: Team Hephy
+name: mychart
+version: 0.1.0
+
+...
+files:
+  mychart-0.1.0.tgz: sha256:5c824605d676f5244aaf70d889f4e58f953308c426f2fa8f970e8fd580eaf363
+-----BEGIN PGP SIGNATURE-----
+
+wsBcBAEBCgAQBQJZuxVACRCEO7+YH8GHYgAAtVMIAEIKSyWH9hb3y/ck6Dwg2Y6v
+6i0kP3L9iCyyTp64XJYiuipdhUO/XK0CxRcLqLa0I5qu658XeU/Qxwb1GTgPoP52
+BCyiJVOY5aXl0SJa+jXHliDak7fgZjUHCtp1HBEKX2uRrx57tTkIjZr7pitt/OwI
+bRz9OXHQe9+fhtAZo5DPtMd53UQ2uRc7xft9HxnwlDEWrBfH6CUNlhbdtKRR5n0s
+FUyR0Eszw/x3No0DdPuH3fo0ShamW9eOFnXIgWqvaeSJthTC5WO5mlSGNEunJKft
+HjQLzdEWppyu55ZS6/oIJdVC2GjUa/PZmKkhYwsMvaWYv+jZWFfhZn8fPYEF0qI=
+=/cXn
+-----END PGP SIGNATURE-----`)
 	badContentNoBeginPGP := []byte("badbadverybad")
 	badContentNoChartName := []byte(`-----BEGIN PGP SIGNED MESSAGE-----
 version: 0.1.0`)
@@ -39,6 +63,10 @@ name: mychart`)
 	filename, err := ProvenanceFilenameFromContent(goodContent)
 	suite.Nil(err, "no error getting filename from good content")
 	suite.Equal("mychart-0.1.0.tgz.prov", filename, "filename generated from good content")
+
+	filename, err := ProvenanceFilenameFromContentWithMaintainerName(goodContentWithMatainerName)
+	suite.Nil(err, "no error getting filename from good content")
+	suite.Equal("mychart-0.1.0.tgz.prov", filename, "filename generated from good content with maintainer name field")
 
 	_, err = ProvenanceFilenameFromContent(badContentNoBeginPGP)
 	suite.Equal(ErrorInvalidProvenanceFile, err, "ErrorInvalidProvenanceFile from bad content, no begin pgp")


### PR DESCRIPTION
Fixes #138 

For some reason I could not test because of a broken vendor package. Are you using go 1.9+? I was building and trying to run tests with 1.8

```
vendor/go.uber.org/zap/field.go:33: syntax error: unexpected = in type declaration
```